### PR TITLE
Add new subsection for transpilers

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,11 @@ See also [Are we (I)DE yet?](https://areweideyet.com/) and [Rust and IDEs](https
 * [trust](https://github.com/japaric/trust) - A Travis CI and AppVeyor template to test your Rust crate on 5 architectures and publish binary releases of it for Linux, macOS and Windows
 * [xd009642/tarpaulin](https://github.com/xd009642/tarpaulin) [[tarpaulin](https://crates.io/crates/cargo-tarpaulin)] — A code coverage tool designed for Rust [<img src="https://api.travis-ci.org/repositories/xd009642/tarpaulin.svg?branch=master">](https://travis-ci.org/xd009642/tarpaulin)
 
+### Transpiling
+
+* [immunant/c2rust](https://github.com/immunant/c2rust) - C to Rust translator and cross checker built atop Clang/LLVM. [![Build Status](https://api.travis-ci.org/immunant/c2rust.svg?branch=master)](https://travis-ci.org/immunant/c2rust)
+* [jameysharp/corrode](https://github.com/jameysharp/corrode) - A C to Rust translator written in Haskell.
+
 ## Libraries
 
 ### Astronomy


### PR DESCRIPTION
Under development tools, add a new subsection to transpilers from C to Rust. In this section, link to Corrode and C2Rust transpilers. Transpilers help developers migrate to Rust by automatically translating C code into (initially unsafe) Rust code that can be further refactored into safe and idiomatic Rust.