### PR TITLE
Add whitfin/bytelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 * [TankerHQ/ruplacer](https://github.com/TankerHQ/ruplacer) — Find and replace text in source files [<img img src="https://api.travis-ci.org/TankerHQ/ruplacer.svg?branch=master">](https://travis-ci.org/TankerHQ/ruplacer)
 * [lavifb/todo_r](https://github.com/lavifb/todo_r) — Find all your TODO notes with one command! [<img src="https://api.travis-ci.org/lavifb/todo_r.svg?branch=master">](https://travis-ci.org/lavifb/todo_r)
 * [whitfin/runiq](https://github.com/whitfin/runiq) — an efficient way to filter duplicate lines from unsorted input.
+* [whitfin/bytelines](https://github.com/whitfin/bytelines) - Read input lines as byte slices for high efficiency.
 
 ### Utilities
 


### PR DESCRIPTION
Adds a small crate for processing lines of text as bytes rather than `String` due to faster throughput.