### PR TITLE
Add network simulation library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1110,6 +1110,7 @@ See also [Are we game yet?](http://arewegameyet.com)
   * [mattnenterprise/rust-ftp](https://github.com/mattnenterprise/rust-ftp) — an [FTP](https://en.wikipedia.org/wiki/File_Transfer_Protocol) client for Rust [<img src="https://api.travis-ci.org/mattnenterprise/rust-ftp.svg?branch=master">](https://travis-ci.org/mattnenterprise/rust-ftp)
 * IPNetwork
   * [achanda/ipnetwork](https://github.com/achanda/ipnetwork) — A library to work with IP networks in pure Rust [<img src="https://api.travis-ci.org/achanda/ipnetwork.svg?branch=master">](https://travis-ci.org/achanda/ipnetwork)
+  * [candrew/netsim](https://github.com/canndrew/netsim) - A Rust library for network simulation and testing [<img src="https://travis-ci.org/canndrew/netsim.svg?branch=master">](https://travis-ci.org/canndrew/netsim)
 * Low level
   * [libpnet/libpnet](https://github.com/libpnet/libpnet) — a cross-platform, low level networking [<img src="https://api.travis-ci.org/libpnet/libpnet.svg?branch=master">](https://travis-ci.org/libpnet/libpnet)
   * [tokio-rs/tokio](https://github.com/tokio-rs/tokio) — a network application framework for rapid development and highly scalable production deployments of clients and servers.


### PR DESCRIPTION
`netsim` is a crate for simulating networks for the sake of testing network-oriented Rust code. You can use it to run Rust functions in network-isolated containers, and assemble virtual networks for these functions to communicate over.