### PR TITLE
Added CrOSVM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1242,6 +1242,7 @@ See also [Are we game yet?](http://arewegameyet.com)
 ### Virtualization
 
 * [beneills/quantum](https://github.com/beneills/quantum) — Advanced Rust quantum computer simulator [<img src="https://api.travis-ci.org/beneills/quantum.svg?branch=master">](https://travis-ci.org/beneills/quantum)
+* [chromium/chromiumos/platform/crosvm](https://chromium.googlesource.com/chromiumos/platform/crosvm/) CrOSVM - Enables Chrome OS to run Linux apps inside a fast, sercure virtualized environment
 * [ekse/unicorn-rs](https://github.com/ekse/unicorn-rs) — Rust bindings for the unicorn CPU emulator
 * [saurvs/hypervisor-rs](https://github.com/saurvs/hypervisor-rs) — Hardware-accelerated virtualization on OS X
 


### PR DESCRIPTION
Google announced at Google IO 2019 that their Chrome OS VM used for running Linux apps on Chrome OS is written in Rust. Source: https://youtu.be/pRlh8LX4kQI?t=483