### PR TITLE
Add mdBook setup GitHub Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
   * [SiegeLord/RustCMake](https://github.com/SiegeLord/RustCMake) — an example project showing usage of CMake with Rust [<img src="https://api.travis-ci.org/SiegeLord/RustCMake.svg?branch=master">](https://travis-ci.org/SiegeLord/RustCMake)
 * Github actions
   * [icepuma/rust-action](https://github.com/icepuma/rust-action) — rust github action
+  * [peaceiris/actions-mdbook](https://github.com/peaceiris/actions-mdbook) - GitHub Actions for mdBook
 * Webpack
   * [Ralvke/rust-loader](https://github.com/Ralvke/rust-loader) — Webpack Rust loader (wasm)
 


### PR DESCRIPTION
Add the link to **GitHub Actions for mdBook (rust-lang/mdBook)**

> Setup mdBook quickly and build your site fast. Linux (Ubuntu), macOS, and Windows are supported.

- repository: https://github.com/peaceiris/actions-mdbook
- marketplace: https://github.com/marketplace/actions/mdbook-action
