### PR TITLE
Add GTSA project

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ See also [Games Made With Piston](https://github.com/PistonDevelopers/piston/wik
 ### Observability
 
 * [timberio/vector](https://github.com/timberio/vector) — A High-Performance, Logs, Metrics, & Events Router.
+* [Mnwa/gtsa](https://github.com/Mnwa/gtsa) — A simple solution to proxy gelf messages (messages for Graylog) to Sentry
 
 ### Operating systems
 


### PR DESCRIPTION
Hey! 
GTSA project it's fasto solution for passing gelf messages to Sentry.