### PR TITLE
Github workflows have started to do 406, unless we add an explicit image to the Accept header

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -95,7 +95,7 @@ fn get_url(url: String) -> BoxFuture<'static, (String, Result<(), CheckerError>)
             debug!("Running {}", url);
             let resp = CLIENT
                 .get(&url)
-                .header(header::ACCEPT, "text/html, */*;q=0.8")
+                .header(header::ACCEPT, "image/svg+xml, text/html, */*;q=0.8")
                 .send()
                 .await;
             match resp {


### PR DESCRIPTION
e.g https://travis-ci.org/rust-unofficial/awesome-rust/builds/655410445