### PR TITLE
Add link to gfx-rs/wgpu library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1139,7 +1139,7 @@ See also [Are we game yet?](https://arewegameyet.com)
 
 [[graphics](https://crates.io/keywords/graphics)]
 
-* [gfx-rs/wgpu](https://github.com/gfx-rs/wgpu) - Native WebGPU implementation based on gfx-hal. [![Build Status](https://github.com/gfx-rs/wgpu/workflows/CI/badge.svg)](https://github.com/gfx-rs/wgpu/actions)
+* [gfx-rs/wgpu](https://github.com/gfx-rs/wgpu) - Native WebGPU implementation based on gfx-hal. [<img src="https://github.com/gfx-rs/wgpu/workflows/CI/badge.svg?branch=master">](https://github.com/gfx-rs/wgpu/actions)
 * [gfx-rs/gfx](https://github.com/gfx-rs/gfx) — A high-performance, bindless graphics API for Rust. [<img src="https://api.travis-ci.org/gfx-rs/gfx.svg?branch=master">](https://travis-ci.org/gfx-rs/gfx)
 * Font
   * [redox-os/rusttype](https://github.com/redox-os/rusttype) — A pure Rust alternative to libraries like FreeType [<img src="https://api.travis-ci.org/redox-os/rusttype.svg?branch=master">](https://travis-ci.org/redox-os/rusttype)

--- a/README.md
+++ b/README.md
@@ -1139,6 +1139,7 @@ See also [Are we game yet?](https://arewegameyet.com)
 
 [[graphics](https://crates.io/keywords/graphics)]
 
+* [gfx-rs/wgpu](https://github.com/gfx-rs/wgpu) - Native WebGPU implementation based on gfx-hal. [![Build Status](https://github.com/gfx-rs/wgpu/workflows/CI/badge.svg)](https://github.com/gfx-rs/wgpu/actions)
 * [gfx-rs/gfx](https://github.com/gfx-rs/gfx) — A high-performance, bindless graphics API for Rust. [<img src="https://api.travis-ci.org/gfx-rs/gfx.svg?branch=master">](https://travis-ci.org/gfx-rs/gfx)
 * Font
   * [redox-os/rusttype](https://github.com/redox-os/rusttype) — A pure Rust alternative to libraries like FreeType [<img src="https://api.travis-ci.org/redox-os/rusttype.svg?branch=master">](https://travis-ci.org/redox-os/rusttype)


### PR DESCRIPTION
The `gfx-rs` group is investing a lot of effort in WebGPU with their library, `wgpu`. `wgpu` is the lowest-level "safe" graphics available, runs both on and off the web, and is generally more approachable to more kinds of users than `gfx-hal`.