### PR TITLE
Add sscache support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: rust
-before_script: cargo install sccache
+before_script: sccache --version || cargo install sccache
 script: RUSTC_WRAPPER=sccache cargo run
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: rust
 before_script: cargo install sccache
-script: cargo run
+script: RUSTC_WRAPPER=sccache cargo run
 
 env:
   global:
     - RUST_LOG=warn
-    - RUSTC_WRAPPER=sccache
     - SCCACHE_CACHE_SIZE=1G
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,15 @@
 language: rust
+before_script: cargo install sccache
 script: cargo run
 
 env:
   global:
     - RUST_LOG=warn
+    - RUSTC_WRAPPER=sccache
+    - SCCACHE_CACHE_SIZE=1G
 
 cache:
   directories:
+    - ~/.cargo/bin
+    - ~/.cache/sccache
     - results # So we don't have to check all the things every time


### PR DESCRIPTION
This seems to get the build of the tool down from ~3m to ~1m15, and seems to work a lot better than the default Rust artifact caching (also has a limit to cache size which should result in it throwing away old data eventually, unlike stock cargo work)