### PR TITLE
Patch 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1315,6 +1315,7 @@ See also [Are we game yet?](https://arewegameyet.rs)
   * [libp2p/rust-libp2p](https://github.com/libp2p/rust-libp2p) — The Rust Implementation of libp2p networking stack. [![Circle CI](https://circleci.com/gh/libp2p/rust-libp2p.svg?style=svg)](https://circleci.com/gh/libp2p/rust-libp2p)
 
 ### Parsing
+
   * [aleshaleksey/libazdice](https://github.com/aleshaleksey/libazdice) — A parser for parsing dice strings for TTRPGs and TTRPG development [<img src="https://api.travis-ci.org/aleshaleksey/libazdice.svg?branch=master">](https://travis-ci.org/aleshaleksey/libazdice)
   * [Folyd/robotstxt](https://github.com/Folyd/robotstxt) - A native Rust port of Google's robots.txt parser and matcher C++ library
   * [Geal/nom](https://github.com/Geal/nom) — parser combinator library [<img src="https://api.travis-ci.org/Geal/nom.svg?branch=master">](https://travis-ci.org/Geal/nom)

--- a/README.md
+++ b/README.md
@@ -1315,7 +1315,7 @@ See also [Are we game yet?](https://arewegameyet.rs)
   * [libp2p/rust-libp2p](https://github.com/libp2p/rust-libp2p) — The Rust Implementation of libp2p networking stack. [![Circle CI](https://circleci.com/gh/libp2p/rust-libp2p.svg?style=svg)](https://circleci.com/gh/libp2p/rust-libp2p)
 
 ### Parsing
-
+  * [aleshaleksey/libazdice](https://github.com/aleshaleksey/libazdice) — A parser for parsing dice strings for TTRPGs and TTRPG development [<img src="https://api.travis-ci.org/aleshaleksey/libazdice.svg?branch=master">](https://travis-ci.org/aleshaleksey/libazdice)
   * [Folyd/robotstxt](https://github.com/Folyd/robotstxt) - A native Rust port of Google's robots.txt parser and matcher C++ library
   * [Geal/nom](https://github.com/Geal/nom) — parser combinator library [<img src="https://api.travis-ci.org/Geal/nom.svg?branch=master">](https://travis-ci.org/Geal/nom)
   * [ivanceras/inquerest](https://github.com/ivanceras/inquerest) — an URL parameter parser for rest filter inquiry [![Build Status](https://api.travis-ci.org/ivanceras/inquerest.svg?branch=master)](https://travis-ci.org/ivanceras/inquerest)


### PR DESCRIPTION
Add a parser (and roller) for various dice strings, which supports addition and subtraction of multiple dice groups with modifiers such as minimum value per dice, maximum value per dice, re-rolls for groups and explosive dice. It also supports generation of probability distributions and has very simple API (incomplete) for use in C/C++. 

In principle this library can be used to parse a string dice roll and then use the resulting "dice bag" for rolls. It should also be useable for making a dice bag using a "button" UI and then rolling it.

In practice it is currently set up to work better as a parser.

NB- I don't know whether this is a little bit trivial for `rust-awesome` but the dice parser on roll20 fails to impress. [Edit: That is not criticism of dice parsing done by various platforms. More to say that this is an attempt to improve on what exists ad provide functionality that some [read: I] would like to see.]