### PR TITLE
Updated the contribution guide with a new template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,8 +11,11 @@ The easiest way is to go to https://github.com/rust-unofficial/awesome-rust/blob
 If you want to add an entry to the `README.md` please consider this:
 
 - is the entry valuable to people trying to get things done in Rust?
-- if you want to add something, please use the template `[YYY](https://crates.io/crates/YYY) — DESCRIPTION [<img src="https://api.travis-ci.org/XXX/YYY.svg?branch=master">](https://travis-ci.org/XXX/YYY)`
-    * If you're adding a build badge please make sure to add the branch information to the image (as per the example above for Travis). For Github actions please see https://docs.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow#example-using-the-branch-parameter
+- if you want to add something, please use the template `[ACCOUNT/REPO](https://github.com/ACCOUNT/REPO) [[CRATE](https://crates.io/crates/CRATE)] — DESCRIPTION`
+    * if you've not published your crate to `crates.io` remove the `[[CRATE](...)]` part.
+    * if you want to add a build badge put the image after the description, separated by a space. Please make sure to add the branch information to the image:
+       * example for Travis: ` [<img src="https://api.travis-ci.org/XXX/CRATE.svg?branch=master">](https://travis-ci.org/XXX/CRATE)`
+       * for Github actions please see https://docs.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow#example-using-the-branch-parameter
 - please pay attention to the alphabetical ordering.
 
 


### PR DESCRIPTION
As offered I updated the contribution guide to use the repository link as a primary link and add an optional `crates.io` link. I hope that's ok.