### PR TITLE
Add cotp

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 * [yaa110/cb](https://github.com/yaa110/cb) — Command line interface to manage clipboard [![Build Status](https://api.travis-ci.org/yaa110/cb.svg?branch=master)](https://travis-ci.org/yaa110/cb)
 * [brycx/checkpwn](https://github.com/brycx/checkpwn) — A Have I Been Pwned (HIBP) command-line utility tool that lets you easily check for compromised accounts and passwords.
 * [evansmurithi/cloak](https://github.com/evansmurithi/cloak) — A Command Line OTP (One Time Password) Authenticator application. [![build badge](https://api.travis-ci.com/evansmurithi/cloak.svg?branch=master">](https://travis-ci.com/evansmurithi/cloak) [<img src="https://ci.appveyor.com/api/projects/status/9mlfpfru3ng4c689/branch/master?svg=true)](https://ci.appveyor.com/project/evansmurithi/cloak)
+* [replydev/cotp](https://github.com/replydev/cotp) - Trustworthy encrypted one time password authenticator app compatible with external backups. [![Actions Status](https://github.com/replydev/cotp/workflows/Rust/badge.svg)](https://github.com/replydev/cotp/actions)
 * [arthrp/consoletimer](https://github.com/arthrp/consoleTimer) — Simple timer for your terminal. [![build badge](https://api.travis-ci.org/arthrp/consoleTimer.svg?branch=master)](https://travis-ci.org/arthrp/consoleTimer)
 * [tversteeg/emplace](https://github.com/tversteeg/emplace) — Synchronize installed packages on multiple machines
 * [myfreeweb/freepass](https://github.com/myfreeweb/freepass) — The free password manager for power users.


### PR DESCRIPTION
# cotp - command line authenticator
### **Description:**
[cotp](https://github.com/replydev/cotp) is a very simple two-factor authentication utility written in **rust** with **simplicity** and **efficiency** in mind. It relies in a single encrypted database file and has only the very important features to manage your codes, no useless stuff.

It can also import **backups** from [Aegis](https://github.com/beemdevelopment/Aegis), [andOTP](https://github.com/andOTP/andOTP), Authy and Google Authenticator.

### **Why i think it should be added in this list:**
I written this little app because i really wanted to manage my two factor authentication codes without using my phone and i didn't find any similar on the internet (except the shitty Authy).
I have also recently discovered [cloak](https://github.com/evansmurithi/cloak) with great pleasure, which is also currently on the list, but I think cotp is a step forward because, as i said, it implements encryption and an import and export system.

I thought I might not be the only one needing a utility like this, I hope someone appreciates this little work.
Thanks for reading this request.     