### PR TITLE
Add Orion lang

### DIFF
--- a/README.md
+++ b/README.md
@@ -1458,6 +1458,7 @@ See also [Are we game yet?](https://arewegameyet.rs)
 * [moss](https://crates.io/crates/moss) — A dynamically typed scripting language
 * [mun](https://github.com/mun-lang/mun) — A compiled, statically-typed scripting language with first class hot reloading support [![build badge](https://api.travis-ci.org/mun-lang/mun.svg?branch=master)](https://travis-ci.org/mun-lang/mun)
 * [rhaiscript/rhai](https://github.com/rhaiscript/rhai) — A tiny and fast embedded scripting language resembling a combination of JS and Rust
+* [Wafelack/orion-lang](https://github.com/Wafelack/orion-lang) — Orion is a lisp inspired statically typed programming language written in Rust
 
 ### Simulation
 


### PR DESCRIPTION
Added [Orion lang](https://github.com/Wafelack/orion-lang) to the Scripting section.