### PR TITLE
Cron jobs to auto-approve for running, and retest the list

### DIFF
--- a/.github/workflows/approve.yml
+++ b/.github/workflows/approve.yml
@@ -1,0 +1,16 @@
+name: Automatic Approve
+on:
+  schedule: 
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+jobs:
+  automatic-approve:
+    name: Automatic Approve
+    runs-on: ubuntu-latest
+    steps:
+      - name: Automatic Approve
+        uses: mheap/automatic-approve-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          workflows: "ci.yml"
+          dangerous_files: "src/main.rs,Cargo.toml,Cargo.lock"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,6 +5,8 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  schedule:
+    - cron: '0 0 * * *'    
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Needs #1097 to fix the build issues.

This PR does two things:
- Enables cron job for automatically re-testing the list each night
- Adds https://github.com/marketplace/actions/automatic-approve to auto-approve for running in Github actions any PRs that make no changes to either the `.github/workflows` or the Rust code for checking things (i.e. anything that could enable abusing the repo to run crypto miners)

After this, it's probably worth disabling the Travis runs, requiring Github actions to work to merge something, and maybe also needing a branch to be up-to-date to merge?