### PR TITLE
Checker: Check the oldest/unchecked ones first

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use std::io::Write;
 use reqwest::{Client, redirect::Policy, StatusCode, header, Url};
 use regex::Regex;
 use failure::{Fail, Error, format_err};
-use chrono::{DateTime, Duration, Local};
+use chrono::{Local, DateTime, Duration};
 use std::env;
 use tokio::sync::Semaphore;
 use tokio::sync::SemaphorePermit;
@@ -121,7 +121,7 @@ fn get_url_core(url: String) -> BoxFuture<'static, (String, Result<(), CheckerEr
     async move {
         let mut res = Err(CheckerError::NotTried);
         for _ in 0..5u8 {
-            info!("Running {}", url);
+            debug!("Running {}", url);
             lazy_static! {
                 static ref GITHUB_REPO_REGEX: Regex = Regex::new(r"^https://github.com/(?P<org>[^/]+)/(?P<repo>[^/]+)$").unwrap();
                 static ref GITHUB_API_REGEX: Regex = Regex::new(r"https://api.github.com/").unwrap();


### PR DESCRIPTION
This means that if for example you've got a new link, we check that first. This means we avoid hitting 429 issues on those due to re-checking other ones that are fine.