### PR TITLE
Add Track Awesome List Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Awesome Rust [![build badge](https://github.com/rust-unofficial/awesome-rust/actions/workflows/rust.yml/badge.svg?branch=master)](https://github.com/rust-unofficial/awesome-rust/actions/workflows/rust.yml)
+# Awesome Rust [![build badge](https://github.com/rust-unofficial/awesome-rust/actions/workflows/rust.yml/badge.svg?branch=master)](https://github.com/rust-unofficial/awesome-rust/actions/workflows/rust.yml) [![Track Awesome List](https://www.trackawesomelist.com/badge.svg)](https://www.trackawesomelist.com/rust-unofficial/awesome-rust)
 
 A curated list of Rust code and resources.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Awesome Rust [![build badge](https://github.com/rust-unofficial/awesome-rust/actions/workflows/rust.yml/badge.svg?branch=master)](https://github.com/rust-unofficial/awesome-rust/actions/workflows/rust.yml) [![Track Awesome List](https://www.trackawesomelist.com/badge.svg)](https://www.trackawesomelist.com/rust-unofficial/awesome-rust)
+# Awesome Rust [![build badge](https://github.com/rust-unofficial/awesome-rust/actions/workflows/rust.yml/badge.svg?branch=master)](https://github.com/rust-unofficial/awesome-rust/actions/workflows/rust.yml) [![Track Awesome List](https://www.trackawesomelist.com/badge.svg)](https://www.trackawesomelist.com/rust-unofficial/awesome-rust/)
 
 A curated list of Rust code and resources.
 


### PR DESCRIPTION
Hi, @palfrey :

I'm Owen, a big fan of rust & awesome-rust. After discovering this awesome list, I read all kinds of interesting items in the entire list. After that, I wanted to see what updates were made to this list every once in a while, and had to go through Github's commit history to see what was updated for each commit. To be honest, it was quite a poor reading experience.

So for this need, I created [Track Awesome List](https://www.trackawesomelist.com) in my spare time, and created a profile for awesome-rust, https://www.trackawesomelist.com/rust-unofficial/awesome-rust . With this link, we can read the latest updates of awesome-rust by day/week, free, daily updated. I wonder if anyone else has this need to see the latest updates, and if so, whether to add this link somewhere in the readme to tell others they can see the updates via this link?

I also created a badge for awesome-rust, which can also be linked to the timeline of awesome-rust.

[![Track Awesome List](https://www.trackawesomelist.com/badge.svg)](https://www.trackawesomelist.com/rust-unofficial/awesome-rust)

```bash
[![Track Awesome List](https://www.trackawesomelist.com/badge.svg)](https://www.trackawesomelist.com/rust-unofficial/awesome-rust)
```

Let me know what you think. I'm happy to receive any feedback or suggestions for improvement. I want this to be as useful as possible.

If you don’t think it’s necessary, that’s okay. I really appreciate you maintaining such an awesome list. I like this list.