### PR TITLE
Add m2cgen for transpiling ML models into Rust code

### DIFF
--- a/README.md
+++ b/README.md
@@ -708,6 +708,7 @@ See also [Are we (I)DE yet?](https://areweideyet.com/) and [Rust Tools](https://
 
 * [immunant/c2rust](https://github.com/immunant/c2rust) — C to Rust translator and cross checker built atop Clang/LLVM. [![Build Status](https://api.travis-ci.org/immunant/c2rust.svg?branch=master)](https://travis-ci.org/immunant/c2rust)
 * [jameysharp/corrode](https://github.com/jameysharp/corrode) — A C to Rust translator written in Haskell.
+* [BayesWitnesses/m2cgen](https://github.com/BayesWitnesses/m2cgen) — A CLI tool to transpile trained classic machine learning models into a native Rust code with zero dependencies. [![GitHub Actions Status](https://github.com/BayesWitnesses/m2cgen/workflows/GitHub%20Actions/badge.svg?branch=master)](https://github.com/BayesWitnesses/m2cgen/actions)
 
 
 ## Libraries


### PR DESCRIPTION
`m2cgen` is a lightweight library written in Python with command line interface which allows to transpile trained machine learning models into a native code of Rust programming language. Examples of generated Rust code can be found [here](https://github.com/BayesWitnesses/m2cgen/tree/master/generated_code_examples/rust).