### PR TITLE
Add Network programming / Bluetooth / bluer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1285,7 +1285,7 @@ See also [Are we game yet?](https://arewegameyet.rs)
 ### Network programming
 
 * Bluetooth
-  * [bluez/bluer](https://github.com/bluez/bluer) [[bluer](https://crates.io/crates/bluer)] — Official BlueZ bindings for Rust. [![build badge](https://github.com/bluez/bluer/actions/workflows/rust.yml/badge.svg?branch=master)](https://github.com/bluez/bluer/actions/workflows/rust.yml) 
+  * [bluez/bluer](https://github.com/bluez/bluer) [[bluer](https://crates.io/crates/bluer)] — Official BlueZ bindings for Rust. [![build badge](https://github.com/bluez/bluer/actions/workflows/rust.yml/badge.svg?branch=master)](https://github.com/bluez/bluer/actions/workflows/rust.yml)
 * CoAP
   * [Covertness/coap-rs](https://github.com/Covertness/coap-rs) — A [Constrained Application Protocol(CoAP)](https://datatracker.ietf.org/doc/html/rfc7252) library for Rust. [![build badge](https://api.travis-ci.org/Covertness/coap-rs.svg?branch=master)](https://travis-ci.org/Covertness/coap-rs)
 * Docker

--- a/README.md
+++ b/README.md
@@ -1264,6 +1264,8 @@ See also [Are we game yet?](https://arewegameyet.rs)
 
 ### Network programming
 
+* Bluetooth
+  * [bluez/bluer](https://github.com/bluez/bluer) [[bluer](https://crates.io/crates/bluer)] — Official BlueZ bindings for Rust. [![build badge](https://github.com/bluez/bluer/actions/workflows/rust.yml/badge.svg?branch=master)](https://github.com/bluez/bluer/actions/workflows/rust.yml) 
 * CoAP
   * [Covertness/coap-rs](https://github.com/Covertness/coap-rs) — A [Constrained Application Protocol(CoAP)](https://datatracker.ietf.org/doc/html/rfc7252) library for Rust. [![build badge](https://api.travis-ci.org/Covertness/coap-rs.svg?branch=master)](https://travis-ci.org/Covertness/coap-rs)
 * Docker


### PR DESCRIPTION
Criteria for adding:

BlueR was called BLEZ and located at https://github.com/surban/blez before it became the official Rust binding for BlueZ and moved to their GitHub organization.

Together the old and new repository have 40 + 28 = 68 stars.