### PR TITLE
Adding  libmdbx-rs fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ See also [Rust — Production](https://www.rust-lang.org/production) organizatio
 * [TerminusDB](https://github.com/terminusdb/terminusdb-store) - open source graph database and document store [![Build Status](https://github.com/terminusdb/terminusdb-store/workflows/Build/badge.svg?branch=master)](https://github.com/terminusdb/terminusdb-store/actions)
 * [tikv](https://github.com/tikv/tikv) — A distributed KV database in Rust [![Build Status](https://ci.pingcap.net/job/tikv_ghpr_test/badge/icon)](https://ci.pingcap.net/job/tikv_ghpr_test/)
 * [WooriDB](https://github.com/naomijub/wooridb) - General purpose time serial database inspired by Crux and Datomic.
+* [libmdbx-rs](https://github.com/vorot93/libmdbx-rs) Rust bindings for MDBX —  fork of [mozilla/lmdb-rs](https://github.com/mozilla/lmdb-rs) with patches to make it work with [libmdbx](https://github.com/erthink/libmdbx). Fast, compact, powerful, embedded, transactional key-value database, with permissive license. 
 
 ### Emulators
 

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ See also [Rust — Production](https://www.rust-lang.org/production) organizatio
 * [TerminusDB](https://github.com/terminusdb/terminusdb-store) - open source graph database and document store [![Build Status](https://github.com/terminusdb/terminusdb-store/workflows/Build/badge.svg?branch=master)](https://github.com/terminusdb/terminusdb-store/actions)
 * [tikv](https://github.com/tikv/tikv) — A distributed KV database in Rust [![Build Status](https://ci.pingcap.net/job/tikv_ghpr_test/badge/icon)](https://ci.pingcap.net/job/tikv_ghpr_test/)
 * [WooriDB](https://github.com/naomijub/wooridb) - General purpose time serial database inspired by Crux and Datomic.
-* [libmdbx-rs](https://github.com/vorot93/libmdbx-rs) Rust bindings for MDBX —  fork of [mozilla/lmdb-rs](https://github.com/mozilla/lmdb-rs) with patches to make it work with [libmdbx](https://github.com/erthink/libmdbx). Fast, compact, powerful, embedded, transactional key-value database, with permissive license. 
+* (mdbx-sys](https://crates.io/crates/mdbx-sys) — Rust bindings for MDBX, a "fast, compact, powerful, embedded, transactional key-value database, with permissive license". This is a fork of [mozilla/lmdb-rs](https://github.com/mozilla/lmdb-rs) with patches to make it work with [libmdbx](https://github.com/erthink/libmdbx)
 
 ### Emulators
 

--- a/README.md
+++ b/README.md
@@ -191,8 +191,8 @@ See also [Rust — Production](https://www.rust-lang.org/production) organizatio
 * [sled](https://crates.io/crates/sled) — A (beta) modern embedded database [![Build Status](https://github.com/spacejam/sled/workflows/Rust/badge.svg?branch=master)](https://github.com/spacejam/sled/actions?workflow=Rust)
 * [TerminusDB](https://github.com/terminusdb/terminusdb-store) - open source graph database and document store [![Build Status](https://github.com/terminusdb/terminusdb-store/workflows/Build/badge.svg?branch=master)](https://github.com/terminusdb/terminusdb-store/actions)
 * [tikv](https://github.com/tikv/tikv) — A distributed KV database in Rust [![Build Status](https://ci.pingcap.net/job/tikv_ghpr_test/badge/icon)](https://ci.pingcap.net/job/tikv_ghpr_test/)
+* [vorot93/libmdbx-rs](https://github.com/vorot93/libmdbx-rs) [[mdbx-sys](https://crates.io/crates/mdbx-sys)] — Rust bindings for MDBX, a "fast, compact, powerful, embedded, transactional key-value database, with permissive license". This is a fork of mozilla/lmdb-rs with patches to make it work with libmdbx.
 * [WooriDB](https://github.com/naomijub/wooridb) - General purpose time serial database inspired by Crux and Datomic.
-* (mdbx-sys](https://crates.io/crates/mdbx-sys) — Rust bindings for MDBX, a "fast, compact, powerful, embedded, transactional key-value database, with permissive license". This is a fork of [mozilla/lmdb-rs](https://github.com/mozilla/lmdb-rs) with patches to make it work with [libmdbx](https://github.com/erthink/libmdbx)
 
 ### Emulators
 


### PR DESCRIPTION
Rust bindings for MDBX —  fork of mozilla/lmdb-rs with patches to make it work with libmdbx.. Fast, compact, powerful, embedded, transactional key-value database, with permissive license.