### PR TITLE
Validate that links are up once a week

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,36 @@
+name: Links
+
+on:
+  schedule:
+    # Run at 00:00 UTC every Sunday
+    - cron: '0 0 * * */7'
+
+env:
+  FORCE_COLOR: 1
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Find markdown files
+        shell: bash
+        run: |
+          echo 'FILES_TO_CHECK<<EOF' >> $GITHUB_ENV
+
+          # $GITHUB_WORKSPACE is where our files live
+          # Ignore dirs and only include markdown files
+
+          files_to_check=$(find $GITHUB_WORKSPACE -type f \
+          -not -path '*/\.git/*' -not -path '*/\.github/*' \
+          -name "*.md")
+
+          echo $files_to_check >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+
+      - name: Validate that links are up
+        uses: simeg/urlsup-action@v1.0.0
+        with:
+          args: ${{ env.FILES_TO_CHECK }} --threads 10


### PR DESCRIPTION
Every Sunday at midnight this Github action will validate that all
http/https links responds with 200. If a link has been permanently
removed (or just moved) it can be removed/changed which leads to a
higher quality list.

This check is already in place in the mac-setup[0] repo and is working
well. It won't prevent any PRs from getting merged, and optionally a
badge can be added to the README to highlight the link status (see
mac-setup repo).

[0]: https://github.com/sb2nov/mac-setup/

---

Hi! I'm curious what you think of my suggestion. I think this will increase the quality of this nice repo! 🙂