### PR TITLE
feat(build-system): add cargo-all-features

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,6 +476,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 ### Build system
 
 * [Cargo](https://crates.io/) — the Rust package manager
+  * [cargo-all-features](https://github.com/frewsxcv/cargo-all-features) - A configurable subcommand to simplify testing, building and much more for all combinations of features [![CI](https://github.com/frewsxcv/cargo-all-features/actions/workflows/ci.yml/badge.svg)](https://github.com/frewsxcv/cargo-all-features/actions/workflows/ci.yml)
   * [cargo-benchcmp](https://crates.io/crates/cargo-benchcmp) — A utility to compare Rust micro-benchmarks [![build badge](https://api.travis-ci.org/BurntSushi/cargo-benchcmp.svg?branch=master)](https://travis-ci.org/BurntSushi/cargo-benchcmp)
   * [cargo-bitbake](https://crates.io/crates/cargo-bitbake) — A cargo extension that can generate BitBake recipes utilizing the classes from meta-rust [![build badge](https://api.travis-ci.org/cardoe/cargo-bitbake.svg?branch=master)](https://travis-ci.org/cardoe/cargo-bitbake)
   * [cargo-cache](https://crates.io/crates/cargo-cache) — inspect/manage/clean your cargo cache (`~/.cargo/`/`${CARGO_HOME}`), print sizes etc [![Build Status](https://github.com/matthiaskrgr/cargo-cache/workflows/ci/badge.svg?branch=master)](https://github.com/matthiaskrgr/cargo-cache/actions)


### PR DESCRIPTION
This PR adds `cargo-all-features` to the `Build system` section.

I'm neither a maintainer of `cargo-all-features` or some rust guru but as a rust lover and community member I have found this crate very useful and lovely as to leveraging the `if it compiles, it runs` sentiment for any kind of feature combinations and it provides another level of checks to reduce tickets, times worrying & prying and needed patches for releases.

I'm not sure if I chose the truly correct section but it seemed to fit the most.

Any feedback is very much welcome 🦀 🥂 

__Edit__:

As for stats:
 - Github starts: 68
 - Crates.io
     * recent: 9'069
     * all time: 43'450

> This does not include any downloads from things like `cargo-binstall` or `cargo-quickinstall`
 