### PR TITLE
Add lborb to learning section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1576,6 +1576,7 @@ A registry allows you to publish your Rust libraries as crate packages, to share
   * [Hands-on Rust](https://pragprog.com/titles/hwrust/hands-on-rust/) - A hands-on guide to learning Rust by making games - by [Herbert Wolverson](https://github.com/thebracket/) (paid)
   * [Idiomatic Rust](https://github.com/mre/idiomatic-rust) —  A peer-reviewed collection of articles/talks/repos which teach idiomatic Rust.
   * [Learning Rust With Entirely Too Many Linked Lists](https://rust-unofficial.github.io/too-many-lists/) — in-depth exploration of Rust's memory management rules, through implementing a few different types of list structures.
+  * [Little Book of Rust Books](https://lborb.github.io/book/) - Curated list of rust books and how-tos.
   * [Programming Community Curated Resources for Learning Rust](https://hackr.io/tutorials/learn-rust) — A list of recommended resources voted by the programming community.
   * [Refactoring to Rust](https://www.manning.com/books/refactoring-to-rust) - A book that introduces to Rust language.
   * [Rust by Example](https://doc.rust-lang.org/rust-by-example/)


### PR DESCRIPTION
Add curated list to awesome-rust. It contains index of various books and quite a few are not listed in here even though seem good (High Assurance Rust, Official Async Book etc.). I see that repo accepts curated lists, so this shouldn't be a problem.