### PR TITLE
Remove outdated crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1039,7 +1039,6 @@ See also [About Rust’s Machine Learning Community](https://medium.com/@autumn_
 * [igiagkiozis/plotly](https://github.com/igiagkiozis/plotly) — Plotly for Rust.
 * [milliams/plotlib](https://github.com/milliams/plotlib) — [![build badge](https://api.travis-ci.org/milliams/plotlib.svg?branch=master)](https://travis-ci.org/milliams/plotlib)
 * [plotters](https://github.com/plotters-rs/plotters) — [![build badge](https://github.com/plotters-rs/plotters/workflows/CI/badge.svg)](https://github.com/plotters-rs/plotters/actions)
-* [saresend/gust](https://github.com/saresend/Gust) — [![build badge](https://api.travis-ci.org/saresend/Gust.svg?branch=master)](https://travis-ci.org/saresend/Gust)
 
 ### Date and time
 


### PR DESCRIPTION
There are a couple of problems with this crate:
1. The badge indicates that it fails to build.
2. It hasn't been updated for over 5 years.
3. It is marked in the README as heavily WIP (and has been for over 5 years without an update).