### PR TITLE
Add SWC

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ See also [Rust — Production](https://www.rust-lang.org/production) organizatio
 * [rx](https://github.com/cloudhead/rx) — Vi inspired Modern Pixel Art Editor
 * [Servo](https://github.com/servo/servo) — A prototype web browser engine
 * [shuttle](https://github.com/shuttle-hq/shuttle) — A serverless platform built for Rust
+* [SWC](https://github.com/swc-project/swc) — super-fast TypeScript / JavaScript compiler
 * [tiny](https://github.com/osa1/tiny) — A terminal IRC client
 * [trust-dns](https://crates.io/crates/trust-dns) — A DNS-server [![Build Status](https://github.com/bluejekyll/trust-dns/workflows/test/badge.svg?branch=main)](https://github.com/bluejekyll/trust-dns/actions?query=workflow%3Atest)
 * [wasmer](https://github.com/wasmerio/wasmer) — A safe and fast WebAssembly runtime supporting WASI and Emscripten [![Build Status](https://github.com/wasmerio/wasmer/workflows/build/badge.svg?style=flat-square)](https://github.com/wasmerio/wasmer/actions)


### PR DESCRIPTION
[SWC](https://swc.rs) is quite a popular Javascript/Typescript parser and transpiler and minifier written in rust.

*This is not a promotion or something.* The project is already well known and exposed on [GitHub trending](https://github.com/trending/rust?since=daily) often for a long time.

below are a few examples of the influence of SWC on both the Rust and JavaScript ecosystems:
- swc is used as a transpiler in [Deno](https://deno.land) under the hood
- ECMAScript parser of swc is used in [Dprint](https://github.com/dprint/dprint-swc-ext) and [rustle](https://github.com/pintariching/rustle).
- swc is used in [Next.js](https://nextjs.org) since v12
- and swc is also used in [turbopack](https://turbo.build/pack) which was introduced recently.

## Checklists
- [x] does the entry have more than 50 stars? - yes
- [x] does the entry have been ordered alphabetically? - yes

*<small>this is my first PR on this repo and maybe I'd done some mistakes, though I've read the [guide](https://github.com/rust-unofficial/awesome-rust/blob/main/CONTRIBUTING.md).
please let me know if any :)</small>*