### PR TITLE
Upgrade actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
     name: Lint Markdown content
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Markdown lint for README
         uses: docker://avtodev/markdown-lint:v1
         with:
@@ -25,7 +25,7 @@ jobs:
     name: Lint for editorconfig violations
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Check for editorconfig violations
         uses: editorconfig-checker/action-editorconfig-checker@v1
 
@@ -34,7 +34,7 @@ jobs:
     name: Lint for Table of Contents
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: 16

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,14 +14,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: stable
-          override: true
           components: rustfmt
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - name: Get random cache id
         run: echo "CACHE_ID=$((RANDOM))" >> $GITHUB_ENV
         shell: bash


### PR DESCRIPTION
Fixing the issue from https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/