### PR TITLE
Add WhatBPM

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ See also [Rust — Production](https://www.rust-lang.org/production) organizatio
 * [Polaris](https://github.com/agersant/polaris) — A music streaming application.  [![build badge](https://api.travis-ci.org/agersant/polaris.svg?branch=master)](https://travis-ci.org/agersant/polaris)
 * [Spotify TUI](https://github.com/Rigellute/spotify-tui) — A Spotify client for the terminal written in Rust. ![Continuous Integration](https://github.com/Rigellute/spotify-tui/workflows/Continuous%20Integration/badge.svg?branch=master)
 * [Spotifyd](https://github.com/Spotifyd/spotifyd) — An open source Spotify client running as a UNIX daemon. ![Continuous Integration](https://github.com/Spotifyd/spotifyd/workflows/Continuous%20Integration/badge.svg?branch=master)
+* [WhatBPM](https://github.com/sergree/whatbpm) — A daily statically generated information resource for electronic dance music producers. Provides daily analytics on the most frequently used values for each EDM genre: tempos, keys, root notes, and so on, using publicly available data such as Beatport and Spotify. ![Continuous Integration](https://github.com/sergree/whatbpm/actions/workflows/website_build_deploy.yml/badge.svg?branch=main)
 
 ### Cryptocurrencies
 


### PR DESCRIPTION
Hello!
I would like to suggest adding [WhatBPM repo].

[WhatBPM] is a daily updated information resource for [EDM] producers, answering questions such as
what [BPM] / [root note] / [key] / [track length] to use for a new production, what [labels][label] to look at, what [EDM] genres are the most trending, and so on. 

The daily analytics provided by [WhatBPM] is based on publicly available data, such as Beatport and Spotify.

It is made with Rust. 
It uses GitHub Actions to update its content daily.
It is served using GitHub Pages.

It has already been supported by such artists as: [nanobii], [Somnia], [Slava Basyul].

Thank you in advance.

[WhatBPM]: https://sergree.github.io/whatbpm/
[WhatBPM repo]: https://github.com/sergree/whatbpm
[EDM]: https://en.wikipedia.org/wiki/Electronic_dance_music
[BPM]: https://en.wikipedia.org/wiki/Tempo
[root note]: https://en.wikipedia.org/wiki/Tonic_(music)
[key]: https://en.wikipedia.org/wiki/Key_(music)
[track length]: https://en.wikipedia.org/wiki/Duration_(music)
[label]: https://en.wikipedia.org/wiki/Record_label

[nanobii]: https://twitter.com/nanobii/status/1596434980540153856
[Somnia]: https://music.apple.com/us/artist/somnia/30407284
[Slava Basyul]: https://www.youtube.com/channel/UCsbS60o4lEjXcicQiMi912A