### PR TITLE
serialport-rs moved to GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1433,7 +1433,7 @@ See also [Are we game yet?](https://arewegameyet.rs)
 ### Peripherals
 
 * Serial Port
-  * [Susurrus/serialport-rs](https://gitlab.com/susurrus/serialport-rs) [[serialport](https://crates.io/crates/serialport)] — A cross-platform library that provides access to a serial port
+  * [serialport/serialport-rs](https://github.com/serialport/serialport-rs) [[serialport](https://crates.io/crates/serialport)] — A cross-platform library that provides access to a serial port
 
 ### Platform specific
 


### PR DESCRIPTION
As mentioned in the README of [the GitLab project](https://gitlab.com/susurrus/serialport-rs), serialport-rs has been moved to GitHub.