### PR TITLE
remove repos made by hostile developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,6 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 ### Security tools
 
 * [AFLplusplus/LibAFL](https://github.com/AFLplusplus/LibAFL) - Advanced Fuzzing Library - Slot your Fuzzer together in Rust! Scales across cores and machines. For Windows, Android, MacOS, Linux, no_std, etc. [![build and test](https://github.com/AFLplusplus/LibAFL/actions/workflows/build_and_test.yml/badge.svg)](https://github.com/AFLplusplus/LibAFL/actions/workflows/build_and_test.yml)
-* [arvancloud/libinjection-rs](https://github.com/arvancloud/libinjection-rs) — Rust bindings for [libinjection](https://github.com/client9/libinjection) [![build badge](https://api.travis-ci.org/arvancloud/libinjection-rs.svg?branch=master)](https://travis-ci.org/arvancloud/libinjection-rs)
 * [cargo-audit](https://crates.io/crates/cargo-audit) - Audit Cargo.lock for crates with security vulnerabilities
 * [cargo-auditable](https://crates.io/crates/cargo-auditable) - Make production Rust binaries auditable
 * [cargo-deny](https://crates.io/crates/cargo-deny) - Cargo plugin to help you manage large dependency graphs
@@ -1452,7 +1451,6 @@ See also [Are we game yet?](https://arewegameyet.rs)
 * FreeBSD
   * [fubarnetes/libjail-rs](https://github.com/fubarnetes/libjail-rs/) [[jail](https://crates.io/crates/jail)] — Rust implementation of a FreeBSD jail library
 * Linux
-  * [arvancloud/nginx-rs](https://github.com/arvancloud/nginx-rs) — [Nginx](https://www.nginx.com) bindings [![build badge](https://api.travis-ci.org/arvancloud/nginx-rs.svg?branch=master)](https://travis-ci.org/arvancloud/nginx-rs)
   * [hannobraun/inotify-rs](https://github.com/hannobraun/inotify-rs) — [inotify](https://en.wikipedia.org/wiki/Inotify) bindings [![Rust](https://github.com/hannobraun/inotify-rs/actions/workflows/rust.yml/badge.svg)](https://github.com/hannobraun/inotify-rs/actions/workflows/rust.yml)
   * [pop-os/distinst](https://github.com/pop-os/distinst/) — Linux distribution installer
   * [yaa110/rust-iptables](https://github.com/yaa110/rust-iptables) [[iptables](https://crates.io/crates/iptables)] — [iptables](https://www.netfilter.org/projects/iptables/index.html) bindings [![build badge](https://api.travis-ci.org/yaa110/rust-iptables.svg?branch=master)](https://travis-ci.org/yaa110/rust-iptables)


### PR DESCRIPTION
This pull request removes repositories made by Arvan Cloud. Arvan cloud has a well known player in restricting Iran's internet, creating spywares against people and helping Islamic Republic of Iran in suppression of  women's rights. Even if their crates does not contain any obvious treats for non-Iranians, they could use future updates to trojan-horse malicious code into countless servers and computers.They have already been sanctioned by EU.  I hope limiting this company's reach could  make this ecosystem far-safer for everyone.

Here are some links to back up some of my claims:
https://netzpolitik.org/2022/nach-investigativer-recherche-eu-verhaengt-sanktionen-gegen-arvancloud/ https://iranwire.com/en/politics/110067-arvancloud-a-firm-sanctioned-for-helping-iran-to-create-a-sanitized-internet/ https://www.iranintl.com/en/202210217439

Please consider that I'm risking my own freedom by doing this. So if at all possible, do the changes your self, and delete this pull request.