### PR TITLE
Add cargo-udeps

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,6 +542,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
   * [cargo-rdme](https://github.com/orium/cargo-rdme) [[cargo-rdme](https://crates.io/crates/cargo-rdme)] — Cargo subcommand to create your README from your crate’s documentation. [![build badge](https://github.com/orium/cargo-rdme/workflows/CI/badge.svg)](https://github.com/orium/cargo-rdme/actions?query=workflow%3ACI)
   * [cargo-release](https://crates.io/crates/cargo-release) — tool for releasing git-managed cargo project, build, tag, publish, doc and push [![Rust](https://github.com/crate-ci/cargo-release/actions/workflows/ci.yml/badge.svg)](https://github.com/crate-ci/cargo-release/actions/workflows/rust.yml)
   * [cargo-script](https://crates.io/crates/cargo-script) — lets people quickly and easily run Rust "scripts" which can make use of Cargo's package ecosystem
+  * [cargo-udeps](https://github.com/est31/cargo-udeps) [[cargo-udeps](https://crates.io/crates/cargo-udeps)] — find unused dependencies
   * [cargo-update](https://crates.io/crates/cargo-update) — cargo subcommand for checking and applying updates to installed executables
   * [cargo-watch](https://crates.io/crates/cargo-watch) — utility for cargo to compile projects when sources change
   * [dtolnay/cargo-expand](https://github.com/dtolnay/cargo-expand) — Expand macros in your source code


### PR DESCRIPTION
Adding [cargo-udeps](https://github.com/est31/cargo-udeps), a tool to find unused dependencies.

I put it in the ["Build system" section](https://github.com/rust-unofficial/awesome-rust/tree/ccf576800c1fafffae81933e9d51b71491424f67#build-system) because similar tools (e.g. [kbknapp/cargo-outdated](https://github.com/kbknapp/cargo-outdated)) are listed there too. Happy to put it anywhere else if that makes more sense.

I followed the format specified in the [Contributing Guidelines](https://github.com/rust-unofficial/awesome-rust/blob/ccf576800c1fafffae81933e9d51b71491424f67/CONTRIBUTING.md) even though most entries in this section don't. Happy to adjust if that's preferred.