### PR TITLE
feat: add decancer to Text Processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1566,6 +1566,7 @@ https://github.com/BinChengZhao/delay-timer/actions)
 * [greyblake/whatlang-rs](https://github.com/greyblake/whatlang-rs) — Natural language detection library based on trigrams
 * [Lucretiel/joinery](https://github.com/Lucretiel/joinery) [[joinery](https://crates.io/crates/joinery)] – Generic string + iterable joining
 * [mgeisler/textwrap](https://github.com/mgeisler/textwrap) [[textwrap](https://crates.io/crates/textwrap)] — Word wrap text (with support for hyphenation)
+* [null8626/decancer](https://github.com/null8626/decancer) [[decancer](https://crates.io/crates/decancer)] — A tiny package that removes common unicode confusables/homoglyphs from strings. [![crates](https://img.shields.io/crates/v/decancer.svg)](https://crates.io/crates/decancer) [![build badge](https://github.com/null8626/decancer/workflows/CI/badge.svg)](https://github.com/null8626/decancer/actions/workflows/CI.yml)
 * [ps1dr3x/easy_reader](https://github.com/ps1dr3x/easy_reader) — A reader that allows forwards, backwards and random navigations through the lines of huge files without consuming iterators
 * [pwoolcoc/ngrams](https://github.com/pwoolcoc/ngrams) [[ngrams](https://crates.io/crates/ngrams)] — Construct [n-grams](https://en.wikipedia.org/wiki/N-gram) from arbitrary iterators
 * [rust-lang/regex](https://github.com/rust-lang/regex) — Regular expressions (RE2 style)


### PR DESCRIPTION
The following pull requests adds [decancer](https://github.com/null8626/decancer) ([crates.io](https://crates.io/crates/decancer)) package to the Text Processing category.

It should be eligible for `awesome-rust` as it has 57 stars at the moment - and other contributing aspects too like:
- 1.1k downloads (all time) on `crates.io`
- 2.1k downloads (per month) on `npm` (it's official Node.js binding)
- it also has an [unofficial Python binding](https://github.com/Jonxslays/decancer_py) too

Again, thank you for this *awesome* curated list of *awesome* projects! ❤️ 