### PR TITLE
Add skillratings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1270,6 +1270,8 @@ See also [Are we game yet?](https://arewegameyet.rs)
   * [Rust-SDL2/rust-sdl2](https://github.com/Rust-SDL2/rust-sdl2) — SDL2 bindings
 * SFML
   * [jeremyletang/rust-sfml](https://github.com/jeremyletang/rust-sfml) — [SFML](https://www.sfml-dev.org/) bindings
+* Skillratings
+  * [atomflunder/skillratings](https://github.com/atomflunder/skillratings) [[skillratings](https://crates.io/crates/skillratings)] - Collection of skill rating algorithms for multiplayer games like Elo, Glicko-2, TrueSkill etc. [![crates.io badge](https://img.shields.io/crates/v/skillratings)](https://crates.io/crates/skillratings) [![CI](https://github.com/atomflunder/skillratings/actions/workflows/ci.yml/badge.svg)](https://github.com/atomflunder/skillratings/actions/workflows/ci.yml)
 * Tcod-rs
   * [tomassedovic/tcod-rs](https://github.com/tomassedovic/tcod-rs) — Libtcod bindings for Rust.
   * Warning: Not maintained anymore


### PR DESCRIPTION
Add skillratings crate to game development category, useful for developing multiplayer games with leaderboards or matchmaking

- https://github.com/atomflunder/skillratings
- https://crates.io/crates/skillratings
