### PR TITLE
Add innnernet to Awesome Rust(Unofficial)

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ See also [Rust — Production](https://www.rust-lang.org/production) organizatio
 * [Fractalide](https://github.com/fractalide/fractalide) — Simple Rust Microservices
 * [habitat](https://github.com/habitat-sh/habitat) — A tool created by Chef to build, deploy, and manage applications.
 * [Herd](https://github.com/imjacobclark/Herd) — an experimental HTTP load testing application
+* [innernet](https://github.com/tonarino/innernet) - An overlay or private mesh network that uses Wireguard under the hood
 * [jedisct1/flowgger](https://github.com/awslabs/flowgger) — A fast, simple and lightweight data collector
 * [kalker](https://github.com/PaddiM8/kalker) - A scientific calculator that supports math-like syntax with user-defined variables, functions, derivation, integration, and complex numbers. Cross platform + WASM support [![Build Status](https://github.com/PaddiM8/kalker/workflows/Release/badge.svg)](https://github.com/PaddiM8/kalker/actions)
 * [kytan](https://github.com/changlan/kytan) — High Performance Peer-to-Peer VPN


### PR DESCRIPTION
Add innernet an overlay or mesh network that uses Wireguard to Awesome Rust.