### PR TITLE
Add Aladin Lite spatial images visualizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -788,6 +788,7 @@ See also [About Rust’s Machine Learning Community](https://medium.com/@autumn_
 
 [[astronomy](https://crates.io/keywords/astronomy)]
 
+* [cds-astro/aladin-lite](https://github.com/cds-astro/aladin-lite) - Web application for visualizing spatial and planetary image surveys in different projections
 * [fitsio](https://crates.io/crates/fitsio) — fits interface library wrapping cfitsio
 * [flosse/rust-sun](https://github.com/flosse/rust-sun) [[sun](https://crates.io/crates/sun)] — A rust port of the JS library suncalc
 * [saurvs/astro-rust](https://github.com/saurvs/astro-rust) — astronomy for Rust


### PR DESCRIPTION
[Aladin Lite](https://github.com/cds-astro/aladin-lite) is a web application developed at CDS for visualizing spatial and planetary image surveys in different wavelengths and projections.

The project was initially developed in 2013 in pure javascript using 2D canvas rendering. Since a few years, a core rust library compiled to WebAssembly has been developed to improve the performance and add new features such as:
* multi all sky projections support
* usage of WebGL for rendering the HEALPix tile images as well as generic FITS images
* adjust the rendered tile pixels on the client side (color, saturation, brightness changes, tranfert function application)
* enhanced core functionalities thanks to the reuse of other rust libraries developed at CDS ([healpix](https://github.com/cds-astro/cds-healpix-rust), [votable](https://github.com/cds-astro/cds-votable-rust), [fitsrs](https://github.com/cds-astro/fitsrs), [wcs](https://github.com/cds-astro/wcs-rs))

Aladin Lite's goals are:
* A lightweight library (700kB for the whole project gzipped) in just one single file
* A javascript API that aims to be exhaustive and simple
* Easy to embed, just copy/paste a few line of JS code to have your [Aladin Lite started](https://aladin.cds.unistra.fr/AladinLite/doc/#embedding)

Over the years, aladin lite is being used by different web portals, portfolios and spatial missions: https://aladin.cds.unistra.fr/AladinLite/doc/#usage

There is a documentation accessible [here](https://aladin.cds.unistra.fr/AladinLite/doc/) for API infos, embedding instructions about Aladin Lite.

A jupyter notebook widget, called [ipyaladin](https://github.com/cds-astro/fitsrs) has been developed for python users. It essentially wraps Aladin Lite with python API bindings.

