### PR TITLE
Add dipc

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ See also [Rust — Production](https://www.rust-lang.org/production) organizatio
 * [cloudflare/boringtun](https://github.com/cloudflare/boringtun) — A Userspace WireGuard VPN Implementation [![build badge](https://img.shields.io/badge/crates.io-v0.2.0-orange.svg)](https://crates.io/crates/boringtun)
 * [datafusion](https://github.com/apache/arrow-datafusion) — Apache Arrow DataFusion and Ballista query engines
 * [denoland/deno](https://github.com/denoland/deno) — A secure JavaScript/TypeScript runtime built with V8, Rust, and Tokio [![Build Status](https://github.com/denoland/deno/workflows/ci/badge.svg?branch=master&event=push)](https://github.com/denoland/deno/actions)
+* [doprz/dipc](https://github.com/doprz/dipc) — Convert your favorite images and wallpapers with your favorite color palettes/themes [![crates.io](https://img.shields.io/crates/v/dipc)](https://crates.io/crates/dipc)
 * [Factotum](https://github.com/snowplow/factotum) — [A system to programmatically run data pipelines](https://snowplow.io/blog/introducing-factotum-data-pipeline-runner/)
 * [fcsonline/drill](https://github.com/fcsonline/drill) — A HTTP load testing application inspired by Ansible syntax
 * [fend](https://github.com/printfn/fend) - Arbitrary-precision unit-aware calculator [![build](https://github.com/printfn/fend/workflows/build/badge.svg)](https://github.com/printfn/fend)


### PR DESCRIPTION
[dipc](https://github.com/doprz/dipc) is a CLI tool written in Rust.

## About

"*Convert your favorite images and wallpapers with your favorite color palettes/themes*"

It can be installed via:
- Homebrew
- Cargo
- AUR

## Checklist

- [x] Have at least 50 stars on GitHub - Yes. dipc currently has 99.
- [x] Entry have been ordered alphabetically - Yes.