### PR TITLE
simulation: update hEngine URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 
 ### Simulation
 
-* [hEngine](https://github.com/hashintel/hash/tree/main/apps/engine) - A Rust-implemented computational simulation engine, supporting large-scale agent-based modelling, with simulation logic written in JavaScript and Python.
+* [hEngine](https://github.com/hashintel/labs/tree/main/apps/sim-engine) - A Rust-implemented computational simulation engine, supporting large-scale agent-based modelling, with simulation logic written in JavaScript and Python.
 
 ### Social networks
 


### PR DESCRIPTION
Project is moved to "/labs" repo.

https://github.com/hashintel/labs/pull/29