### PR TITLE
Add `helsing-ai/buffrs` and add `### Package Managers`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ If you want to contribute, please read [this](CONTRIBUTING.md).
   * [Industrial automation](#industrial-automation)
   * [Observability](#observability)
   * [Operating systems](#operating-systems)
+  * [Package Managers](#package-managers)
   * [Payments](#payments)
   * [Productivity](#productivity)
   * [Routing protocols](#routing-protocols)
@@ -337,6 +338,10 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 * [thepowersgang/rust_os](https://github.com/thepowersgang/rust_os) —
 * [theseus-os/Theseus](https://github.com/theseus-os/Theseus) — A safe-language, single address space and single privilege level OS written from scratch in pure Rust - [![build badge](https://img.shields.io/github/workflow/status/theseus-os/Theseus/Documentation?label=docs%20build)](https://www.theseus-os.com/Theseus/book/index.html)
 * [tock/tock](https://github.com/tock/tock) — A secure embedded operating system for Cortex-M based microcontrollers
+
+### Package Managers
+
+* [helsing-ai/buffrs](https://github.com/helsing-ai/buffrs) [[buffrs](https://crates.io/crates/buffrs)] — A modern package manager for protocol buffers and gRPC architectures.
 
 ### Payments
 


### PR DESCRIPTION
I had to introduce an according category as no application category matched this project.

#### What is Buffrs about?

Buffrs is a package manager for protocol buffers and gRPC architectures. It allows engineers to create semantically versioned libraries and apis in protobuf and lint and publish them using `buffrs`. The project ships a cli and soon a registry component.

#### Why did i add it?

It is a great learning resource for others (and a way easier one to learn than cargo!) on how to build a package manager in rust and: In the protocol buffers ecosystem this actually fills in a big gap of tooling. Making it visible for people should drive adoption, get people to write their ideas, usecases and feature requests to us. 