### PR TITLE
Updated README: Added Zed to IDEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -741,6 +741,7 @@ See also [Are we (I)DE yet?](https://areweideyet.com/) and [Rust Tools](https://
     * [Prettier - Code formatter (Rust)](https://marketplace.visualstudio.com/items?itemName=jinxdash.prettier-rust) — Opinionated Rust code formatter that autofixes bad syntax ([Prettier](https://prettier.io/) community plugin)
     * [rust-analyzer](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer) — An alternative rust language server to the RLS
     * [rust-lang/rls-vscode](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust) — Rust support for Visual Studio Code (supports both RLS and rust-analyzer)
+  * [Zed](https://zed.dev/) — a high-performance, multiplayer code editor from the creators of Atom and Tree-sitter for macOS.
 
 ### Profiling
 


### PR DESCRIPTION
Added Zed to the `README` under the IDE category.

Zed provides Rust syntax highlighting and auto-complete through rust-analyzer. If the user doesn't have the necessary LSP for the filetype, Zed will download and run it in the background for them.

Despite only being for macOS currently, Linux/Windows clients are planned/being worked on based on their GitHub community page as well.