### PR TITLE
docs: add node-ffi-rs

### DIFF
--- a/README.md
+++ b/README.md
@@ -695,8 +695,7 @@ See also [Foreign Function Interface](https://doc.rust-lang.org/book/first-editi
 * Node.js
   * [infinyon/node-bindgen](https://github.com/infinyon/node-bindgen) - Easy way to generate nodejs module using Rust
   * [neon-bindings/neon](https://github.com/neon-bindings/neon) — Rust bindings for writing safe and fast native Node.js modules
-  * [zhangyuang/node-ffi-rs](https://github.com/zhangyuang/node-ffi-rs) — A module written by Rust and N-API provides interface (FFI) features for Node.js
-
+  * [zhangyuang/node-ffi-rs](https://github.com/zhangyuang/node-ffi-rs) — A module written in Rust and N-API provides interface (FFI) features for Node.js
 * Objective-C
   * [SSheldon/rust-objc](https://github.com/SSheldon/rust-objc) — Objective-C Runtime bindings and wrapper for Rust
 * PHP

--- a/README.md
+++ b/README.md
@@ -695,6 +695,8 @@ See also [Foreign Function Interface](https://doc.rust-lang.org/book/first-editi
 * Node.js
   * [infinyon/node-bindgen](https://github.com/infinyon/node-bindgen) - Easy way to generate nodejs module using Rust
   * [neon-bindings/neon](https://github.com/neon-bindings/neon) — Rust bindings for writing safe and fast native Node.js modules
+  * [zhangyuang/node-ffi-rs](https://github.com/zhangyuang/node-ffi-rs) — A module written by Rust and N-API provides interface (FFI) features for Node.js
+
 * Objective-C
   * [SSheldon/rust-objc](https://github.com/SSheldon/rust-objc) — Objective-C Runtime bindings and wrapper for Rust
 * PHP


### PR DESCRIPTION
[ffi-rs](https://github.com/zhangyuang/node-ffi-rs) is a high performance module written in Rust and N-API that provides FFI (Foreign Function Interface) features for Node.js. It allows developers to call functions written in other languages such as C++, C, and Rust directly from JavaScript without writing any C++ code.

This module aims to provide similar functionality to the node-ffi module, but with a completely rewritten underlying codebase. The node-ffi module has been unmaintained for several years and is no longer usable, which is why ffi-rs was developed.