### PR TITLE
replacing `spotify-tui` with `spotify-player`

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ See also [Rust — Production](https://www.rust-lang.org/production) organizatio
 * [Glicol](https://github.com/chaosprint/glicol) — Graph-oriented live coding language written in Rust for collaborative musicking in browsers.
 * [ncspot](https://github.com/hrkfdn/ncspot) - Cross-platform ncurses Spotify client, inspired by ncmpc and the likes. [![build badge](https://github.com/hrkfdn/ncspot/workflows/Build/badge.svg)](https://github.com/hrkfdn/ncspot/actions?query=workflow%3ABuild)
 * [Polaris](https://github.com/agersant/polaris) — A music streaming application.
-* [Spotify TUI](https://github.com/Rigellute/spotify-tui) — A Spotify client for the terminal written in Rust. ![Continuous Integration](https://github.com/Rigellute/spotify-tui/workflows/Continuous%20Integration/badge.svg?branch=master)
+* [Spotify Player](https://github.com/aome510/spotify-player) — A Spotify player in the terminal with full feature parity.
 * [Spotifyd](https://github.com/Spotifyd/spotifyd) — An open source Spotify client running as a UNIX daemon. ![Continuous Integration](https://github.com/Spotifyd/spotifyd/workflows/Continuous%20Integration/badge.svg?branch=master)
 * [termusic](https://github.com/tramhao/termusic) - Music Player TUI written in Rust
 * [WhatBPM](https://github.com/sergree/whatbpm) — A daily statically generated information resource for electronic dance music producers. Provides daily analytics on the most frequently used values for each EDM genre: tempos, keys, root notes, and so on, using publicly available data such as Beatport and Spotify. ![Continuous Integration](https://github.com/sergree/whatbpm/actions/workflows/website_build_deploy.yml/badge.svg?branch=main)


### PR DESCRIPTION
since spotify-tui seems to be [unmaintained](https://github.com/Rigellute/spotify-tui/issues/1000), there's [spotify-player](https://github.com/aome510/spotify-player) which seems to be very good.

depends on: https://github.com/rust-unofficial/awesome-rust/pull/1636