### PR TITLE
Add the arp-scan-rs project

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 ### Security tools
 
 * [AFLplusplus/LibAFL](https://github.com/AFLplusplus/LibAFL) - Advanced Fuzzing Library - Slot your Fuzzer together in Rust! Scales across cores and machines. For Windows, Android, MacOS, Linux, no_std, etc. [![build and test](https://github.com/AFLplusplus/LibAFL/actions/workflows/build_and_test.yml/badge.svg)](https://github.com/AFLplusplus/LibAFL/actions/workflows/build_and_test.yml)
+* [arp-scan-rs](https://github.com/kongbytes/arp-scan-rs) - A minimalistic ARP scan tool for fast local network scans
 * [cargo-audit](https://crates.io/crates/cargo-audit) - Audit Cargo.lock for crates with security vulnerabilities
 * [cargo-auditable](https://crates.io/crates/cargo-auditable) - Make production Rust binaries auditable
 * [cargo-crev](https://crates.io/crates/cargo-crev) - A cryptographically verifiable code review system for the cargo (Rust) package manager.


### PR DESCRIPTION
The "arp-scan-rs" project is a minimalistic ARP scan tool written in Rust for fast local network scans - inspired by the [arp-scan project](https://github.com/royhills/arp-scan) written in C.