### PR TITLE
feat: add async-dropper to asynchronous libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -884,6 +884,7 @@ See also [About Rust’s Machine Learning Community](https://medium.com/@autumn_
 * [dpc/mioco](https://github.com/dpc/mioco) — Scalable, coroutine-based, asynchronous IO handling library
 * [mio](https://github.com/tokio-rs/mio) — MIO is a lightweight IO library for Rust with a focus on adding as little overhead as possible over the OS abstractions
 * [rust-lang/futures-rs](https://github.com/rust-lang/futures-rs) — Zero-cost futures in Rust
+* [t3hmrman/async-dropper](https://github.com/t3hmrman/async-dropper) [[async-dropper](https://crates.io/crates/async-dropper)] - Implementation of `AsyncDrop`
 * [TeaEntityLab/fpRust](https://github.com/TeaEntityLab/fpRust) — Monad/MonadIO, Handler, Coroutine/doNotation, Functional Programming features for Rust
 * [Xudong-Huang/may](https://github.com/Xudong-Huang/may) — rust stackful coroutine library
 * [zonyitoo/coio-rs](https://github.com/zonyitoo/coio-rs) — A coroutine I/O library with a working-stealing scheduler


### PR DESCRIPTION
Thanks for the awesome listing! I added my project `async-dropper` which is for people who want an `AsyncDrop` -- it has two implementations (one derive macro based, the other a simple wrapper object)