### PR TITLE
Actions upgrade for node 16 issues

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
     name: Lint Markdown content
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Markdown lint for README
         uses: docker://avtodev/markdown-lint:v1
         with:
@@ -25,16 +25,16 @@ jobs:
     name: Lint for editorconfig violations
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Check for editorconfig violations
-        uses: editorconfig-checker/action-editorconfig-checker@v1
+        uses: editorconfig-checker/action-editorconfig-checker@v2
 
   lint-markdown-toc:
     runs-on: ubuntu-latest
     name: Lint for Table of Contents
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
           node-version: 16

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,9 +21,8 @@ jobs:
           components: rustfmt
       - uses: Swatinem/rust-cache@v2
       - name: Load results cache
-        uses: actions/cache@v4
+        uses: pat-s/always-upload-cache@v3.0.11
         with:
-          save-always: true
           path: results/*.yaml
           key: results-${{ hashFiles('Cargo.lock') }}-${{ hashFiles('README.md') }}-${{ github.run_id }}
           restore-keys: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,15 +20,12 @@ jobs:
           toolchain: stable
           components: rustfmt
       - uses: Swatinem/rust-cache@v2
-      - name: Get random cache id
-        run: echo "CACHE_ID=$((RANDOM))" >> $GITHUB_ENV
-        shell: bash
       - name: Load rust cache
         uses: actions/cache@v4
         with:
           save-always: true
           path: results/*.yaml
-          key: results-${{ hashFiles('Cargo.lock') }}-${{ hashFiles('README.md') }}-${{ env.CACHE_ID }}
+          key: results-${{ hashFiles('Cargo.lock') }}-${{ hashFiles('README.md') }}-${{ github.run_id }}
           restore-keys: |
             results-${{ hashFiles('Cargo.lock') }}-${{ hashFiles('README.md') }}-
             results-${{ hashFiles('Cargo.lock') }}-

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,7 +20,7 @@ jobs:
           toolchain: stable
           components: rustfmt
       - uses: Swatinem/rust-cache@v2
-      - name: Load rust cache
+      - name: Load results cache
         uses: actions/cache@v4
         with:
           save-always: true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
@@ -23,8 +23,10 @@ jobs:
       - name: Get random cache id
         run: echo "CACHE_ID=$((RANDOM))" >> $GITHUB_ENV
         shell: bash
-      - uses: pat-s/always-upload-cache@v3.0.11
+      - name: Load rust cache
+        uses: actions/cache@v4
         with:
+          save-always: true
           path: results/*.yaml
           key: results-${{ hashFiles('Cargo.lock') }}-${{ hashFiles('README.md') }}-${{ env.CACHE_ID }}
           restore-keys: |


### PR DESCRIPTION
Fixes all bar the always-upload-cache. I've filed a bug there (https://github.com/pat-s/always-upload-cache/issues/3) to fix it, or at some point `actions/cache` might be usable for this now, but that has it's own issue (https://github.com/actions/cache/issues/1315)