### PR TITLE
Add Raspirus

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 * [kpcyrd/sn0int](https://github.com/kpcyrd/sn0int) — A semi-automatic OSINT framework and package manager
 * [kpcyrd/sniffglue](https://github.com/kpcyrd/sniffglue) — A secure multithreaded packet sniffer
 * [ObserverWard](https://github.com/0x727/ObserverWard) — Community based web technologies analysis tool.
+* [Raspirus](https://github.com/Raspirus/Raspirus) - User- and resources-friendly signatures-based malware scanner [![status](https://github.com/Raspirus/Raspirus/actions/workflows/testproject.yml/badge.svg)](https://github.com/Raspirus/Raspirus/actions/workflows/testproject.yml)
 * [ripasso](https://github.com/cortex/ripasso/) — A password manager, filesystem compatible with pass
 * [rustscan/rustscan](https://github.com/RustScan/RustScan) — Make Nmap faster with this port scanning tool [![build badge](https://github.com/RustScan/RustScan/workflows/Continuous%20integration/badge.svg?branch=master)](https://github.com/RustScan/RustScan/actions?query=workflow%3A%22Continuous+integration%22)
 


### PR DESCRIPTION
Raspirus is a small malware scanner that focuses on being easy to use and as efficient as possible, making it able to work even on Raspberry Pis

Requirements:
- [x] At least 50 stars on GitHub
- [x] 2000 downloads