### PR TITLE
Update README.md: adds teocloud/teo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1810,6 +1810,7 @@ See also [Are we web yet?](https://www.arewewebyet.org) and [Rust web framework 
   * [tokio/axum](https://github.com/tokio-rs/axum) - Ergonomic and modular web framework built with Tokio, Tower, and Hyper [![Build badge](https://github.com/tokio-rs/axum/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/tokio-rs/axum/actions/workflows/CI.yml)
   * [tomaka/rouille](https://github.com/tomaka/rouille) — Web framework
   * [Zino](https://github.com/zino-rs/zino) — Next-generation framework for composable applications
+  * [Teo](https://github.com/teocloud/teo) - Schema-centered web framework which can provide frontend convenience and generate an admin dashboard
 * Miscellaneous
   * [cargonauts](https://github.com/cargonauts-rs/cargonauts) — A web framework intended for building maintainable, well-factored web apps.
   * [causal-agent/scraper](https://github.com/causal-agent/scraper) [[scraper](https://crates.io/crates/scraper)] - HTML parsing and querying with CSS selectors. [![Build Status](https://github.com/causal-agent/scraper/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/causal-agent/scraper/actions)


### PR DESCRIPTION
This commit adds [teocloud/teo](https://github.com/teocloud/teo).

Teo is a web framework for Rust which utilizes a innovative schema language. And it can generate frontend client packages for web requests.

Official website: https://www.teodev.io/

It can even generate an admin dashboard: https://blog.teodev.io/articles/announcing-teo-admin-dashboard-beta
