### PR TITLE
Update `icepuma/rust-action` to `Mirlahiji/rust-action`

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,7 +661,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
   * [SiegeLord/RustCMake](https://github.com/SiegeLord/RustCMake) — an example project showing usage of CMake with Rust
 * [Fleet](https://github.com/dimensionhq/fleet) [[fleet-rs](https://crates.io/crates/fleet-rs)] - The blazing fast build tool for Rust.
 * GitHub actions
-  * [icepuma/rust-action](https://github.com/icepuma/rust-action) — rust github action
+  * [Mirlahiji/rust-action](https://github.com/Mirlahiji/rust-action) — rust github action
   * [peaceiris/actions-mdbook](https://github.com/peaceiris/actions-mdbook) — GitHub Actions for mdBook
 * [Nix](https://nixos.org/)
   * [nix-community/fenix](https://github.com/nix-community/fenix) — Rust toolchains and rust analyzer nightly for nix [![build-badge](https://github.com/nix-community/fenix/actions/workflows/ci.yml/badge.svg)](https://github.com/nix-community/fenix/actions/workflows/ci.yml)


### PR DESCRIPTION
I noticed that [icepuma/rust-action](https://github.com/icepuma/rust-action) is no longer maintained and the README suggested using [Mirlahiji/rust-action](https://github.com/Mirlahiji/rust-action) (a fork) instead.