### PR TITLE
Add tracexec

### DIFF
--- a/README.md
+++ b/README.md
@@ -671,6 +671,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 
 * GDB
   * [gdbgui](https://github.com/cs01/gdbgui) - Browser based frontend for gdb to debug C, C++, Rust, and go.
+* [kxxt/tracexec](https://github.com/kxxt/tracexec) [[tracexec](https://crates.io/crates/tracexec)] - Tracer for execve{,at} and pre-exec behavior, launcher for debuggers.
 * LLDB
   * [CodeLLDB](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb) - A LLDB extension for [Visual Studio Code](https://code.visualstudio.com/).
 


### PR DESCRIPTION
tracexec is a tracer for execve{,at} and pre-exec behavior, and launcher for debuggers. 

In general, it's useful for debugging build systems, understanding what shell scripts actually do, figuring out what programs does a proprietary software run and attaching debuggers to complex multi-process scripts/applications.