### PR TITLE
add perpetual - a gradient boosting machine in Rust

### DIFF
--- a/README.md
+++ b/README.md
@@ -893,6 +893,7 @@ See also [About Rust’s Machine Learning Community](https://medium.com/@autumn_
 * [rust-ml/linfa](https://github.com/rust-ml/linfa) — Machine learning framework.
 * [smartcorelib/smartcore](https://github.com/smartcorelib/smartcore) — Machine Learning Library [![Build Status](https://img.shields.io/circleci/build/github/smartcorelib/smartcore)](https://smartcorelib.org/)
 * [tensorflow/rust](https://github.com/tensorflow/rust) — Bindings for TensorFlow.
+* [perpetual-ml/perpetual](https://github.com/perpetual-ml/perpetual) — A self-generalizing, hyperparameter-free gradient boosting machine.
 
 #### OpenAI
 


### PR DESCRIPTION
PerpetualBooster is a gradient boosting machine (GBM) algorithm which doesn't have hyperparameters to be tuned so that you can use it without needing hyperparameter optimization packages unlike other GBM algorithms.