### PR TITLE
Added cargo-depgraph, replacement for cargo-deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,12 +640,13 @@ See also [A comparison of operating systems written in Rust](https://github.com/
   * [cargo-commander](https://crates.io/crates/cargo-commander) - A subcommand for `cargo` to run CLI commands similar to how the scripts section in `package.json` works [![Build and test](https://github.com/simonhyll/cargo-commander/actions/workflows/build.yml/badge.svg)](https://github.com/simonhyll/cargo-commander/actions/workflows/build.yml)
   * [cargo-count](https://crates.io/crates/cargo-count) - lists source code counts and details about cargo projects, including unsafe statistics
   * [cargo-deb](https://crates.io/crates/cargo-deb) - Generates binary Debian packages
-  * [cargo-deps](https://crates.io/crates/cargo-deps) - build dependency graphs
+  * [cargo-depgraph](https://crates.io/crates/cargo-depgraph) - Creates dependency graphs for cargo projects using cargo metadata and graphviz
+  * [cargo-deps](https://crates.io/crates/cargo-deps) - build dependency graphs. Unmaintained, see `cargo-depgraph`
   * [cargo-do](https://crates.io/crates/cargo-do) - run multiple cargo commands in a row
   * [cargo-ebuild](https://crates.io/crates/cargo-ebuild) - cargo extension that can generate ebuilds using the in-tree eclasses
   * [cargo-edit](https://crates.io/crates/cargo-edit) - allows you to add and list dependencies by reading/writing to your Cargo.toml file from the command line
   * [cargo-generate](https://github.com/cargo-generate/cargo-generate) - A generator of a rust project by leveraging a pre-existing git repository as a template.
-  * [cargo-graph](https://crates.io/crates/cargo-graph) - updated fork of `cargo-dot` with additional features. Unmaintained, see `cargo-deps`
+  * [cargo-graph](https://crates.io/crates/cargo-graph) - updated fork of `cargo-dot` with additional features. Unmaintained, see `cargo-depgraph`
   * [cargo-info](https://crates.io/crates/cargo-info) - queries crates.io for crates details from command line
   * [cargo-license](https://crates.io/crates/cargo-license) - A cargo subcommand to quickly view the licenses of all dependencies.
   * [cargo-limit](https://crates.io/crates/cargo-limit) - Cargo with less noise: warnings are skipped until errors are fixed, Neovim integration, etc. [![build badge](https://github.com/cargo-limit//cargo-limit/actions/workflows/rust.yml/badge.svg)](https://github.com/cargo-limit//cargo-limit/actions)

--- a/README.md
+++ b/README.md
@@ -641,12 +641,10 @@ See also [A comparison of operating systems written in Rust](https://github.com/
   * [cargo-count](https://crates.io/crates/cargo-count) - lists source code counts and details about cargo projects, including unsafe statistics
   * [cargo-deb](https://crates.io/crates/cargo-deb) - Generates binary Debian packages
   * [cargo-depgraph](https://crates.io/crates/cargo-depgraph) - Creates dependency graphs for cargo projects using cargo metadata and graphviz
-  * [cargo-deps](https://crates.io/crates/cargo-deps) - build dependency graphs. Unmaintained, see `cargo-depgraph`
   * [cargo-do](https://crates.io/crates/cargo-do) - run multiple cargo commands in a row
   * [cargo-ebuild](https://crates.io/crates/cargo-ebuild) - cargo extension that can generate ebuilds using the in-tree eclasses
   * [cargo-edit](https://crates.io/crates/cargo-edit) - allows you to add and list dependencies by reading/writing to your Cargo.toml file from the command line
   * [cargo-generate](https://github.com/cargo-generate/cargo-generate) - A generator of a rust project by leveraging a pre-existing git repository as a template.
-  * [cargo-graph](https://crates.io/crates/cargo-graph) - updated fork of `cargo-dot` with additional features. Unmaintained, see `cargo-depgraph`
   * [cargo-info](https://crates.io/crates/cargo-info) - queries crates.io for crates details from command line
   * [cargo-license](https://crates.io/crates/cargo-license) - A cargo subcommand to quickly view the licenses of all dependencies.
   * [cargo-limit](https://crates.io/crates/cargo-limit) - Cargo with less noise: warnings are skipped until errors are fixed, Neovim integration, etc. [![build badge](https://github.com/cargo-limit//cargo-limit/actions/workflows/rust.yml/badge.svg)](https://github.com/cargo-limit//cargo-limit/actions)

--- a/README.md
+++ b/README.md
@@ -1847,7 +1847,7 @@ See also [Are we web yet?](https://www.arewewebyet.org) and [Rust web framework 
   * [cobalt-org/cobalt.rs](https://github.com/cobalt-org/cobalt.rs) - Static site generator [![Build Status](https://dev.azure.com/cobalt-org/cobalt-org/_apis/build/status/cobalt.rs?branchName=master)](https://dev.azure.com/cobalt-org/cobalt-org/_build?definitionId=2)
   * [FuGangqiang/mdblog.rs](https://github.com/FuGangqiang/mdblog.rs) [[mdblog](https://crates.io/crates/mdblog)] - Static site generator from markdown files.
   * [getzola/zola](https://github.com/getzola/zola) [[zola](https://www.getzola.org/)] - An opinionated static site generator with everything built-in. [![Build Status](https://dev.azure.com/getzola/zola/_apis/build/status/getzola.zola?branchName=master)](https://dev.azure.com/getzola/zola/_build)
-  * [grego/blades](https://github.com/grego/blades) [[blades](https://getblades.org/)] - Blazing fast dead simple static site generator.
+  * [grego/blades](https://github.com/grego/blades) [[blades](https://www.getblades.org/)] - Blazing fast dead simple static site generator.
   * [leven-the-blog/leven](https://github.com/leven-the-blog/leven) [[leven](https://crates.io/crates/leven)] - A simple, parallelized blog generator.
 * [WebSocket](https://datatracker.ietf.org/doc/rfc6455/)
   * [housleyjk/ws-rs](https://github.com/housleyjk/ws-rs) - lightweight, event-driven WebSockets


### PR DESCRIPTION
Crates.IO README for cargo-deps says the project is no longer worked on and that users should consider using either cargo-depgraph or cargo-tree. Since cargo-tree is included in cargo, I added cargo-depgraph.