### PR TITLE
Removed crates - repo archived

### DIFF
--- a/README.md
+++ b/README.md
@@ -798,7 +798,6 @@ See also [Are we (I)DE yet?](https://areweideyet.com/) and [Rust Tools](https://
   * [Visual Studio Code](https://code.visualstudio.com/)
     * [Better TOML](https://marketplace.visualstudio.com/items?itemName=bungcip.better-toml) - TOML support in vscode
     * [CodeLLDB](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb) - A LLDB extension
-    * [crates](https://github.com/serayuzgur/crates) - crates is an extension for crates.io dependencies. [![build badge](https://img.shields.io/vscode-marketplace/v/serayuzgur.crates.svg)](https://github.com/serayuzgur/crates)
     * [Prettier - Code formatter (Rust)](https://marketplace.visualstudio.com/items?itemName=jinxdash.prettier-rust) - Opinionated Rust code formatter that autofixes bad syntax ([Prettier](https://prettier.io/) community plugin)
     * [rust-analyzer](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer) - An alternative rust language server to the RLS
 


### PR DESCRIPTION
Found this when I ran the build locally without the results yaml files. It failed because archived repos are treated as zero stars.

The https://github.com/serayuzgur/crates repo has been archived and is now pointing users to https://github.com/filllabs/dependi (a typescript project so no replacement for this list)
