### PR TITLE
Replace json-rust with jzon-rust

### DIFF
--- a/README.md
+++ b/README.md
@@ -1345,8 +1345,8 @@ See also [About Rust’s Machine Learning Community](https://medium.com/@autumn_
   * [servo/html5ever](https://github.com/servo/html5ever) - High-performance browser-grade HTML5 parser
 * JSON
   * [importcjj/rust-ajson](https://github.com/importcjj/rust-ajson) [[ajson](https://crates.io/crates/ajson)] - Get JSON values quickly
-  * [maciejhirsz/json-rust](https://github.com/maciejhirsz/json-rust) [[json](https://crates.io/crates/json)] - JSON implementation
   * [pikkr/pikkr](https://github.com/pikkr/pikkr) [[pikkr](https://crates.io/crates/pikkr)] - JSON parser which picks up values directly without performing tokenization
+  * [rustadopt/jzon-rs](https://github.com/rustadopt/jzon-rs/) [[jzon](https://crates.io/crates/jzon)] - JSON implementation
   * [serde-rs/json](https://github.com/serde-rs/json) [[serde\_json](https://crates.io/crates/serde_json)] - JSON support for [Serde](https://github.com/serde-rs/serde) framework
   * [simd-lite/simd-json](https://github.com/simd-lite/simd-json) [[simd-json](https://crates.io/crates/simd-json)] - High performance JSON parser based on a port of simdjson
 * MsgPack


### PR DESCRIPTION
`json-rust` is now regarded as abandoned.
https://rustsec.org/advisories/RUSTSEC-2022-0081.html

`jzon-rust` is a community-driven fork of `json-rust`.