### PR TITLE
add `Peroxide` numeric library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1096,6 +1096,7 @@ See also [About Rust’s Machine Learning Community](https://medium.com/@autumn_
 * Science
   * [cpmech/russell](https://github.com/cpmech/russell) - Rust Scientific Library for numerical mathematics, ordinary differential equations, special math functions, high-performance (sparse) linear algebra
   * [indigits/scirust](https://github.com/indigits/scirust) - Scientific computing library
+  * [Axect/Peroxide](https://github.com/Axect/Peroxide) - Rust numeric library containing linear algebra, numerical analysis, statistics and machine learning tools in pure rust
 * Statrs
   * [statrs-dev/statrs](https://github.com/statrs-dev/statrs) - Robust statistical computation library
 

--- a/README.md
+++ b/README.md
@@ -1094,9 +1094,9 @@ See also [About Rust’s Machine Learning Community](https://medium.com/@autumn_
   * [autumnai/collenchyma](https://github.com/autumnai/collenchyma) - An extensible, pluggable, backend-agnostic framework for parallel, high-performance computations on CUDA, OpenCL and common host CPU.
   * [luqmana/rust-opencl](https://github.com/luqmana/rust-opencl) - [OpenCL](https://www.khronos.org/opencl/) bindings
 * Science
+  * [Axect/Peroxide](https://github.com/Axect/Peroxide) - Rust numeric library containing linear algebra, numerical analysis, statistics and machine learning tools in pure rust
   * [cpmech/russell](https://github.com/cpmech/russell) - Rust Scientific Library for numerical mathematics, ordinary differential equations, special math functions, high-performance (sparse) linear algebra
   * [indigits/scirust](https://github.com/indigits/scirust) - Scientific computing library
-  * [Axect/Peroxide](https://github.com/Axect/Peroxide) - Rust numeric library containing linear algebra, numerical analysis, statistics and machine learning tools in pure rust
 * Statrs
   * [statrs-dev/statrs](https://github.com/statrs-dev/statrs) - Robust statistical computation library
 

--- a/README.md
+++ b/README.md
@@ -1096,7 +1096,6 @@ See also [About Rust’s Machine Learning Community](https://medium.com/@autumn_
 * Science
   * [Axect/Peroxide](https://github.com/Axect/Peroxide) - Rust numeric library containing linear algebra, numerical analysis, statistics and machine learning tools in pure rust
   * [cpmech/russell](https://github.com/cpmech/russell) - Rust Scientific Library for numerical mathematics, ordinary differential equations, special math functions, high-performance (sparse) linear algebra
-  * [indigits/scirust](https://github.com/indigits/scirust) - Scientific computing library
 * Statrs
   * [statrs-dev/statrs](https://github.com/statrs-dev/statrs) - Robust statistical computation library
 


### PR DESCRIPTION
I was looking for something like this and the options listed are not really helpful since:

- scirust is unmaintained since 7 year. (Should we just scratch it at this point?)
- russell isn't written in pure rust which makes it less cross platform than `Peroxide` and I need that
- `peroxide` is actively maintained