### PR TITLE
Add "MLOps" sub-category and include TensorZero project

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ If you want to contribute, please read [this](CONTRIBUTING.md).
   * [Image processing](#image-processing)
   * [Industrial automation](#industrial-automation)
   * [Message Queue](#message-queue)
+  * [MLOps](#mlops)
   * [Observability](#observability)
   * [Operating systems](#operating-systems)
   * [Package Managers](#package-managers)
@@ -361,6 +362,10 @@ See also [Games Made With Piston](https://github.com/PistonDevelopers/piston/wik
 ### Message Queue
 
 * [RobustMQ](https://github.com/robustmq/robustmq) - Next generation cloud-native converged message queue.
+
+### MLOps
+
+* [TensorZero](https://github.com/tensorzero/tensorzero) - data & learning flywheel for LLMs that unifies inference, observability, optimization, and experimentation ![TensorZero Build Status](https://img.shields.io/github/check-runs/tensorzero/tensorzero/main)
 
 ### Observability
 


### PR DESCRIPTION
Along with my submission, I'm proposing a new sub-category under Applications: `MLOps`. Rust is increasingly being used for high-performance MLOps tooling, so it'd be great to showcase them!

I'm including an open-source project I co-authored: https://github.com/tensorzero/tensorzero

Let me know if this is not a good fit, and I'd be happy to move it elsewhere. Thanks!