### PR TITLE
add brush shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 * [bandwhich](https://github.com/imsnif/bandwhich) - Terminal bandwidth utilization tool
 * [bottom](https://github.com/ClementTsang/bottom) - Yet another cross-platform graphical process/system monitor. [![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/ClementTsang/bottom/ci/master)](https://github.com/ClementTsang/bottom/actions?query=branch%3Amaster)
 * [brocode/fblog](https://github.com/brocode/fblog) - Small command-line JSON Log viewer
+* [brush-shell](https://github.com/reubeno/brush) - bash/POSIX-compatible shell [![CICD](https://github.com/reubeno/brush/actions/workflows/ci.yaml/badge.svg)](https://github.com/reubeno/brush/actions/workflows/ci.yaml)[![Crate](https://img.shields.io/crates/v/brush-shell.svg?logo=rust)](https://crates.io/crates/brush-shell)
 * [bustd](https://github.com/vrmiguel/bustd) - Lightweight process killer daemon to handle out-of-memory scenarios on Linux. [![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/vrmiguel/bustd/build-and-test)](https://github.com/vrmiguel/bustd/actions?query=branch%3Amaster)
 * [buster/rrun](https://github.com/buster/rrun) - A command launcher for Linux, similar to gmrun
 * [cantino/mcfly](https://github.com/cantino/mcfly) - Fly through your shell history. Great Scott!


### PR DESCRIPTION
I'm proposing adding [brush](https://github.com/reubeno/brush) to system tools list, now that its download count on [crates.io](https://crates.io/crates/brush-shell) has gone above 3,000:

[![Crates.io](https://img.shields.io/crates/d/brush-shell?style=flat-square)](https://crates.io/crates/brush-shell)

I'm the primary maintainer of the project and happy to answer any questions about it. This is also my first proposed addition to this list and am happy to take any feedback you have on this change. Thanks in advance for your consideration!