### PR TITLE
Add samba

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ See also [Rust - Production](https://www.rust-lang.org/production) organizations
 * [Rio](https://github.com/raphamorim/rio) - A hardware-accelerated GPU terminal emulator powered by WebGPU, focusing to run in desktops and browsers.
 * [rx](https://github.com/cloudhead/rx) - Vi inspired Modern Pixel Art Editor
 * [Ryot](https://github.com/ignisda/ryot) - A self hosted application to track media consumption, fitness, etc.
+* [samba](https://gitlab.com/ballroom-dancing/samba) - A smart and mechanic ballroom assistant.
 * [Servo](https://github.com/servo/servo) - A prototype web browser engine
 * [shoes](https://github.com/cfal/shoes) - A multi-protocol proxy server
 * [shuttle](https://github.com/shuttle-hq/shuttle) - A serverless platform.


### PR DESCRIPTION
This adds [samba](https://gitlab.com/ballroom-dancing/samba). I like this software, because it combines Rust and VueJS

In a nutshell, samba aims to be of service (and not in the way) of dancing clubs and active dancers, for regular practice, competition practice, and all the other dancing related matters.

![Library view](https://gitlab.com/ballroom-dancing/samba/-/raw/main/resources/library-view.png)

![Edit practice session](https://gitlab.com/ballroom-dancing/samba/-/raw/main/resources/edit-practice-session.png)
