### PR TITLE
Remove notty

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,6 @@ See also [Rust - Production](https://www.rust-lang.org/production) organizations
 * [mdBook](https://github.com/rust-lang/mdBook) - A command line utility to create books from markdown files [![Build Status](https://github.com/rust-lang/mdBook/workflows/CI/badge.svg?branch=master)](https://github.com/rust-lang/mdBook/actions)
 * [mirrord](https://github.com/metalbear-co/mirrord) - Connect your local process and your cloud environment, and run local code in cloud conditions
 * [nicohman/eidolon](https://github.com/nicohman/eidolon) - A steam and drm-free game registry and launcher for linux and macosx
-* [notty](https://github.com/withoutboats/notty) - A new kind of terminal
 * [Pijul](https://pijul.org) - A patch-based distributed version control system
 * [Rauthy](https://github.com/sebadob/rauthy) - OpenID Connect Single Sign-On Identity & Access Management
 * [Rio](https://github.com/raphamorim/rio) - A hardware-accelerated GPU terminal emulator powered by WebGPU, focusing to run in desktops and browsers.


### PR DESCRIPTION
First of all, thanks for such a great project. I am a beginner trying to make an open source contribution, and I found this project while looking for a suitable github repo.

Then, by chance, I looked into a project [`notty`](https://github.com/withoutboats/notty). The last update is 7 years ago and the author said [the project is dead](https://github.com/withoutboats/notty/issues/67#issuecomment-354379883).