### PR TITLE
Add Rust Skill Tree to Resource/Learning section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1944,6 +1944,7 @@ A registry allows you to publish your Rust libraries as crate packages, to share
   * [exercism.org](https://exercism.org/tracks/rust) - programming exercises that help you learn new concepts in Rust.
   * [Hands-on Rust](https://pragprog.com/titles/hwrust/hands-on-rust/) - A hands-on guide to learning Rust by making games - by [Herbert Wolverson](https://github.com/thebracket/) (paid)
   * [Idiomatic Rust](https://github.com/mre/idiomatic-rust) - A peer-reviewed collection of articles/talks/repos which teach idiomatic Rust.
+  * [LabEx Rust Skill Tree](https://labex.io/skilltrees/rust) - A structured Rust learning path with hands-on labs, designed for beginners to master Rust step by step.
   * [Learn Rust by 500 lines code](https://github.com/cuppar/rtd) - Learn Rust by 500 lines code, build a Todo Cli Application from scratch.
   * [Learning Rust With Entirely Too Many Linked Lists](https://rust-unofficial.github.io/too-many-lists/) - in-depth exploration of Rust's memory management rules, through implementing a few different types of list structures.
   * [Little Book of Rust Books](https://lborb.github.io/book/) - Curated list of rust books and how-tos.


### PR DESCRIPTION
Add Rust Skill Tree to Resource/Learning section

I work at LabEx, a unique learning platform that has delivered thousands of hands-on labs over the past 7 years. Our Rust Skill Tree currently offers 30 foundational skills and 200+ hands-on labs, making it perfect for beginners to learn step by step. We've now added the Rust Skill Tree to our learning section.

This repo is a great resource for Rust users. Please let me know if any changes are needed.
