### PR TITLE
Add 'A Brief History of Rust. Part 1, 2 and 3' under Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1931,6 +1931,7 @@ A registry allows you to publish your Rust libraries as crate packages, to share
 
 ## Resources
 
+* [A Brief History of Rust. Part 1](https://medium.com/rustaceans/make-it-mandatory-a-brief-history-of-rust-part-1-805459c60c6b) - From a developer's pursuit of software stability to a project that nearly destabilized its creator. [Part 2](https://medium.com/rustaceans/make-it-mandatory-a-brief-history-of-rust-part-2-981d61451aa5). [Part 3](https://medium.com/rustaceans/make-it-mandatory-a-brief-history-of-rust-part-2-b8c0f7a7e781?sk=c0e7fe5fde11a62edc23f284f125aa18).
 * Benchmarks
   * [c410-f3r/wtx-bench](https://github.com/c410-f3r/wtx-bench) - Web benchmarks
   * [TeXitoi/benchmarksgame-rs](https://github.com/TeXitoi/benchmarksgame-rs) - Implementations for the [The Computer Language Benchmarks Game](https://benchmarksgame-team.pages.debian.net/benchmarksgame/)
@@ -1977,7 +1978,6 @@ A registry allows you to publish your Rust libraries as crate packages, to share
   * [New Rustacean](https://newrustacean.com) - A podcast about learning Rust
   * [Rustacean Station](https://rustacean-station.org/) - A community project for creating podcast content for Rust
 * [Rust Design Patterns](https://github.com/rust-unofficial/patterns) - A catalogue of Rust design patterns, anti-patterns and idioms
-* [A Brief History of Rust. Part 1](https://medium.com/rustaceans/make-it-mandatory-a-brief-history-of-rust-part-1-805459c60c6b) - From a developer's pursuit of software stability to a project that nearly destabilized its creator. [Part 2](https://medium.com/rustaceans/make-it-mandatory-a-brief-history-of-rust-part-2-981d61451aa5). [Part 3](https://medium.com/rustaceans/make-it-mandatory-a-brief-history-of-rust-part-2-b8c0f7a7e781?sk=c0e7fe5fde11a62edc23f284f125aa18).
 * [Rust Guidelines](http://aturon.github.io/) - Aaron Turon's blog posts on rust
 * [Rust Servers, Services and Apps - MEAP](https://www.manning.com/books/rust-servers-services-and-apps) - Build backend servers, services, and front-ends in Rust to get fast, reliable, and maintainable applications.
 * [Rust Subreddit](https://www.reddit.com/r/rust/) - A subreddit(forum) where rust related questions, articles and resources are posted and discussed

--- a/README.md
+++ b/README.md
@@ -1977,6 +1977,7 @@ A registry allows you to publish your Rust libraries as crate packages, to share
   * [New Rustacean](https://newrustacean.com) - A podcast about learning Rust
   * [Rustacean Station](https://rustacean-station.org/) - A community project for creating podcast content for Rust
 * [Rust Design Patterns](https://github.com/rust-unofficial/patterns) - A catalogue of Rust design patterns, anti-patterns and idioms
+* [A Brief History of Rust. Part 1](https://medium.com/rustaceans/make-it-mandatory-a-brief-history-of-rust-part-1-805459c60c6b) - From a developer's pursuit of software stability to a project that nearly destabilized its creator. [Part 2](https://medium.com/rustaceans/make-it-mandatory-a-brief-history-of-rust-part-2-981d61451aa5). [Part 3](https://medium.com/rustaceans/make-it-mandatory-a-brief-history-of-rust-part-2-b8c0f7a7e781?sk=c0e7fe5fde11a62edc23f284f125aa18).
 * [Rust Guidelines](http://aturon.github.io/) - Aaron Turon's blog posts on rust
 * [Rust Servers, Services and Apps - MEAP](https://www.manning.com/books/rust-servers-services-and-apps) - Build backend servers, services, and front-ends in Rust to get fast, reliable, and maintainable applications.
 * [Rust Subreddit](https://www.reddit.com/r/rust/) - A subreddit(forum) where rust related questions, articles and resources are posted and discussed


### PR DESCRIPTION
Hi, Tom
I’m submitting a contribution with three articles that provide a concise history of Rust. These articles are valuable resources for Rustaceans interested in learning about the evolution of Rust. Each article has received over 100 claps on Medium, reflecting positive reader engagement. Importantly, all provided links are accessible for free, and for the paywalled article, I have included a friend link to ensure free access.

Thank you for considering this addition! I believe it will be a helpful resource for the Rust community.

Best regards,
Bin Wu