### PR TITLE
chore: add PSP project

### DIFF
--- a/README.md
+++ b/README.md
@@ -783,6 +783,7 @@ See also [Foreign Function Interface](https://doc.rust-lang.org/book/first-editi
   * [getsentry/milksnake](https://github.com/getsentry/milksnake) - extension for python setuptools that allows you to distribute dynamic linked libraries in Python wheels in the most portable way imaginable.
   * [PyO3/PyO3](https://github.com/PyO3/PyO3) - Rust bindings for the Python interpreter
   * [RustPython](https://github.com/RustPython/RustPython) - A Python Interpreter written in Rust [![Build Status](https://github.com/RustPython/RustPython/workflows/CI/badge.svg)](https://github.com/RustPython/RustPython/actions?query=workflow%3ACI)
+  * [MatteoGuadrini/PSP](https://github.com/MatteoGuadrini/psp) - A Python Scaffolding tool for new project written in Rust
 * Ruby
   * [d-unsed/ruru](https://github.com/d-unsed/ruru) - native Ruby extensions written in Rust
   * [danielpclark/rutie](https://github.com/danielpclark/rutie) - native Ruby extensions written in Rust and vice versa


### PR DESCRIPTION
`psp` is a blazing fast command line utility to scaffold your Python project, written in Rust.

* ⚡️ 10-100x faster
* 🛠️ pyproject.toml support
* 🤝 Python 3.13 compatibility
* 🗃 Scaffolding file and folder structures for your Python project
* 📦 Unit-test and [pytest](https://docs.pytest.org/) supports
* 🧪 Create virtual environment
* 🔧 Automatically dependencies installation
* 🪛 Add build and deploy dependencies to distribute package
* 📏 [tox](https://tox.wiki/en/stable/) configuration supports and remotes CI like [CircleCI](https://circleci.com/) and [TravisCI](https://www.travis-ci.com/)
* ⌨️ [MkDocs](https://www.mkdocs.org/) and [Sphinx](https://www.sphinx-doc.org/) documentation supports
* 🧰 Initialize git repository and gitignore file
* 🌎 Github and Gitlab remote repository supports
* 📑 Create README, LICENSE, CONTRIBUTING, CODE_OF_CONDUCT and CHANGES files
* 🐳 Create Dockerfile and Containerfile for your project
* 💡 Can use quick, simple and full argument for rapid configuration

Demo:
![image](https://global.discourse-cdn.com/flex016/uploads/python1/original/3X/9/e/9eb605b8aa76e65e994f720648f5393e561f31b7.gif)
