### PR TITLE
Add "binarly-io/idalib" under the new "reverse engineering" category

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ If you want to contribute, please read [this](CONTRIBUTING.md).
   * [Parsing](#parsing)
   * [Peripherals](#peripherals)
   * [Platform specific](#platform-specific)
+  * [Reverse engineering](#reverse-engineering)
   * [Scripting](#scripting)
   * [Simulation](#simulation)
   * [Social networks](#social-networks-1)
@@ -1741,7 +1742,8 @@ See also [Are we game yet?](https://arewegameyet.rs)
   * [retep998/winapi-rs](https://github.com/retep998/winapi-rs) - Windows API bindings [![Rust](https://github.com/retep998/winapi-rs/actions/workflows/rust.yml/badge.svg?branch=dev)](https://github.com/retep998/winapi-rs/actions/workflows/rust.yml)
 
 ### Reverse engineering
-* [binarly-io/idalib](https://github.com/binarly-io/idalib) [[idalib](https://crates.io/crates/idalib)] — Rust bindings for the IDA SDK, enabling the development of standalone analysis tools using IDA v9.0’s idalib
+
+* [binarly-io/idalib](https://github.com/binarly-io/idalib) [[idalib](https://crates.io/crates/idalib)] - Rust bindings for the IDA SDK, enabling the development of standalone analysis tools using IDA v9.0’s idalib
 
 ### Scripting
 

--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 * [espanso](https://github.com/espanso/espanso) - A cross-platform Text Expander. [![CI](https://github.com/espanso/espanso/actions/workflows/ci.yml/badge.svg?branch=dev&event=push)](https://github.com/espanso/espanso/actions/workflows/ci.yml)
 * [eureka](https://crates.io/crates/eureka) - A CLI tool to input and store your ideas without leaving the terminal
 * [Furtherance](https://github.com/unobserved-io/Furtherance) - Time tracking app built with GTK4
-* [illacloud/illa](https://github.com/illacloud/illa) [[ILLA Cloud](https://illacloud.com)] - Low-code internal tool builder.
+* [illacloud/illa](https://github.com/illacloud/illa) [[ILLA Cloud](https://www.illacloud.com/)] - Low-code internal tool builder.
 * [LLDAP](https://github.com/lldap/lldap) - Simplified LDAP interface for authentication.
 * [pier-cli/pier](https://github.com/pier-cli/pier) - A central repository to manage (add, search metadata, etc.) all your one-liners, scripts, tools, and CLIs
 * [ShadoySV/work-break](https://github.com/ShadoySV/work-break) [[work-break](https://crates.io/crates/work-break)] - Work and rest time balancer taking into account your current and today strain [![Build](https://github.com/shadoysv/work-break/actions/workflows/release.yml/badge.svg)](https://github.com/ShadoySV/work-break/releases)

--- a/README.md
+++ b/README.md
@@ -1740,6 +1740,9 @@ See also [Are we game yet?](https://arewegameyet.rs)
   * [microsoft/windows-rs](https://github.com/microsoft/windows-rs) - Rust for Windows [![Actions Status](https://github.com/microsoft/windows-rs/workflows/CI/badge.svg)](https://github.com/microsoft/windows-rs/actions)
   * [retep998/winapi-rs](https://github.com/retep998/winapi-rs) - Windows API bindings [![Rust](https://github.com/retep998/winapi-rs/actions/workflows/rust.yml/badge.svg?branch=dev)](https://github.com/retep998/winapi-rs/actions/workflows/rust.yml)
 
+### Reverse engineering
+* [binarly-io/idalib](https://github.com/binarly-io/idalib) [[idalib](https://crates.io/crates/idalib)] — Rust bindings for the IDA SDK, enabling the development of standalone analysis tools using IDA v9.0’s idalib
+
 ### Scripting
 
 [[scripting](https://crates.io/keywords/scripting)]


### PR DESCRIPTION
I'm using this library to develop reverse engineering and security tools. I think it would be a great addition to the list, but I couldn't find a suitable category, so I added one. I hope it's ok!