### PR TITLE
Add "Finance" app category and Tackler-NG accounting application

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ See also [crates matching keyword 'emulator'](https://crates.io/keywords/emulato
 
 See also [Payments](#payments) applications.
 
+* [e257-fi/tackler-ng](https://github.com/e257-fi/tackler-ng) [[tackler](https://crates.io/crates/tackler)] - Fast, reliable bookkeeping engine with native GIT SCM support for plain text accounting [![CI Badge](https://github.com/e257-fi/tackler-ng/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/e257-fi/tackler-ng/blob/main/.github/workflows/ci.yml)
 
 ### Games
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ If you want to contribute, please read [this](CONTRIBUTING.md).
   * [Embedded](#embedded)
   * [Emulators](#emulators)
   * [File manager](#file-manager)
+  * [Finance](#finance)
   * [Games](#games)
   * [Graphics](#graphics)
   * [Image processing](#image-processing)
@@ -82,7 +83,7 @@ If you want to contribute, please read [this](CONTRIBUTING.md).
   * [Email](#email)
   * [Encoding](#encoding)
   * [Filesystem](#filesystem)
-  * [Finance](#finance)
+  * [Finance](#finance-1)
   * [Functional Programming](#functional-programming)
   * [Game development](#game-development)
   * [Geospatial](#geospatial)
@@ -321,6 +322,12 @@ See also [crates matching keyword 'emulator'](https://crates.io/keywords/emulato
 * [joshuto](https://github.com/kamiyaa/joshuto) - ranger-like terminal file manager
 * [xplr](https://github.com/sayanarijit/xplr) - A hackable, minimal, fast TUI file explorer
 * [yazi](https://github.com/sxyazi/yazi) - Blazing fast terminal file manager, based on async I/O.
+
+
+### Finance
+
+See also [Payments](#payments) applications.
+
 
 ### Games
 

--- a/README.md
+++ b/README.md
@@ -323,7 +323,6 @@ See also [crates matching keyword 'emulator'](https://crates.io/keywords/emulato
 * [xplr](https://github.com/sayanarijit/xplr) - A hackable, minimal, fast TUI file explorer
 * [yazi](https://github.com/sxyazi/yazi) - Blazing fast terminal file manager, based on async I/O.
 
-
 ### Finance
 
 See also [Payments](#payments) applications.


### PR DESCRIPTION
Hello, 

This PR adds similar "Finance" application category as there is for libraries.  

And secondly, it adds Tackler-NG to that Finance  application category.  Tackler-NG is fast, 
reliable bookkeeping engine with native GIT SCM support for plain text accounting.

Github: https://github.com/e257-fi/tackler-ng
Crates.io: https://crates.io/crates/tackler

Sorry to stepping ahead if the  finance application category doesn't make sense, then please just reject this PR and I will make a new one without it. In that case, would the top level Application list be ok for tackler?