### PR TITLE
Add fish shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,6 +493,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 * [diskonaut](https://github.com/imsnif/diskonaut) - Terminal visual disk space navigator
 * [dust](https://github.com/bootandy/dust) - A more intuitive version of du
 * [eza-community/eza](https://github.com/eza-community/eza) - A replacement for 'ls'
+* [fish-shell/fish-shell](https://github.com/fish-shell/fish-shell) - The user-friendly command line shell
 * [fselect](https://crates.io/crates/fselect) - Find files with SQL-like queries
 * [gitui](https://github.com/gitui-org/gitui) - Blazing fast terminal client for git. [![build](https://github.com/gitui-org/gitui/workflows/CI/badge.svg?branch=master)](https://github.com/gitui-org/gitui/actions)
 * [GQL](https://github.com/amrdeveloper/gql) - A SQL like query language to run on .git files.


### PR DESCRIPTION
<https://github.com/fish-shell/fish-shell>

This shell has been ported from C++ to Rust since version 4.0.0.[^1] This shell has not yet been published on <https://crates.io/>.

[^1]: <https://fishshell.com/docs/current/relnotes.html#fish-4-0-0-released-february-27-2025>