### PR TITLE
added libs.tech

### DIFF
--- a/README.md
+++ b/README.md
@@ -2046,6 +2046,7 @@ A registry allows you to publish your Rust libraries as crate packages, to share
 * [RustCamp 2015 Talks](https://www.youtube.com/playlist?list=PLE7tQUdRKcybdIw61JpCoo89i4pWU5f_t) - Recorded talks from RustCamp 2015
 * [RustViz](https://github.com/rustviz/rustviz) - generates visualizations from simple Rust programs to assist users in better understanding the Rust Lifetime and Borrowing mechanism.
 * [Watch Jon Gjengset Implement BitTorrent in Rust](https://www.youtube.com/watch?v=jf_ddGnum_4) - Implementing (part of) a BitTorrent client in Rust
+* [libs.tech/rust](https://libs.tech/rust) – Awesome Rust libraries and hidden gems
 
 ## License
 


### PR DESCRIPTION
Added libs.tech (direct link to Rust category). Libs.tech helps devs stay on top of ecosystems they're interested in.

https://libs.tech/rust