### PR TITLE
Add license-fetcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -1652,6 +1652,10 @@ See also [Are we game yet?](https://arewegameyet.rs)
 
 * [shnewto/bnf](https://github.com/shnewto/bnf) - A library for parsing Backus–Naur form context-free grammars.
 
+### Licensing
+
+* [WyvernIXTL/license-fetcher](https://github.com/WyvernIXTL/license-fetcher) [[license-fetcher](https://crates.io/crates/license-fetcher)] - Fetch licenses of dependencies at build time and embed them into your program.
+
 ### Logging
 
 [[log](https://crates.io/keywords/log)]


### PR DESCRIPTION
This PR adds [`license-fetcher`](https://github.com/WyvernIXTL/license-fetcher), a library meant to be used for generating license information in a structured way at build time, and for displaying said, then embedded license information at runtime with very few dependencies.

I am not quite sure if this libraries total downloads fit the requirements: [crates.io](https://crates.io/crates/license-fetcher) states that it has **9.532** downloads total / all time (though that is likely bloated).

Thanks for taking your time!
