### PR TITLE
add differential-equations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1179,6 +1179,7 @@ See also [About Rust’s Machine Learning Community](https://medium.com/@autumn_
 * Science
   * [Axect/Peroxide](https://github.com/Axect/Peroxide) - Rust numeric library containing linear algebra, numerical analysis, statistics and machine learning tools in pure rust
   * [cpmech/russell](https://github.com/cpmech/russell) - Rust Scientific Library for numerical mathematics, ordinary differential equations, special math functions, high-performance (sparse) linear algebra
+  * [Ryan-D-Gast/differential-equations](https://github.com/Ryan-D-Gast/differential-equations) - A high-performance library for numerically solving differential equations
 * Statrs
   * [statrs-dev/statrs](https://github.com/statrs-dev/statrs) - Robust statistical computation library
 


### PR DESCRIPTION
Adding crate `differential-equations` to the Computing -> Science section. Significantly more feature-rich and has an idiomatic API than previous Rust implementations. Additionally, benchmarking is faster than the gold standard Fortran implementations.