### PR TITLE
Add RepoFlow to Registries section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2025,6 +2025,7 @@ A registry allows you to publish your Rust libraries as crate packages, to share
 * [cenotelie/cratery](https://github.com/cenotelie/cratery) - A lightweight private cargo registry with batteries included, built for organisations, including features similar to [docs.rs](https://docs.rs) and [deps.rs](https://deps.rs). [![CI](https://github.com/cenotelie/cratery/actions/workflows/ci.yml/badge.svg)](https://github.com/cenotelie/cratery/actions/workflows/ci.yml)
 * [Cloudsmith :heavy_dollar_sign:](https://cloudsmith.com/product/formats/cargo-registry) - A fully managed package management SaaS, with first-class support for public and private Cargo/Rust registries (plus many others). Has a generous free-tier and is also completely free for open-source.
 * [Crates](https://crates.io) - The official public registry for Rust/Cargo.
+* [RepoFlow](https://www.repoflow.io) - A simple and modern repository platform that can host Rust crate repositories and proxy crates.io. Also supports other package types like Docker, PyPI, Maven, npm, and RubyGems. Available as a cloud service or self-hosted.
 * [w4/chartered](https://github.com/w4/chartered) - A private, authenticated, permissioned Cargo registry [![CI](https://github.com/w4/chartered/actions/workflows/ci.yml/badge.svg)](https://github.com/w4/chartered/actions/workflows/ci.yml)
 
 ## Resources

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,7 @@ lazy_static! {
         "https://github.com/andoriyu/uclicious", // FIXME: CI hack. the crate has a higher count, but we don't refresh.
         "https://marketplace.visualstudio.com/items?itemName=fill-labs.dependi", // marketplace link , but also has enough stars
         "https://github.com/TraceMachina/nativelink", // 1.4k stars, probably broken because @palfrey now works for them...
-        "https://app.repoflow.io/repoflow-public/package/f429fabf-6289-49c2-acd9-791b39eac746", // added per discussion in the RepoFlow pull request: https://github.com/rust-unofficial/awesome-rust/pull/2054
+        "https://www.repoflow.io", // added per discussion in the RepoFlow pull request: https://github.com/rust-unofficial/awesome-rust/pull/2054 (see package downloads: https://app.repoflow.io/repoflow-public/package/f429fabf-6289-49c2-acd9-791b39eac746)
     ].iter().map(|s| s.to_string()).collect();
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,6 +81,7 @@ lazy_static! {
         "https://github.com/andoriyu/uclicious", // FIXME: CI hack. the crate has a higher count, but we don't refresh.
         "https://marketplace.visualstudio.com/items?itemName=fill-labs.dependi", // marketplace link , but also has enough stars
         "https://github.com/TraceMachina/nativelink", // 1.4k stars, probably broken because @palfrey now works for them...
+        "https://app.repoflow.io/repoflow-public/package/f429fabf-6289-49c2-acd9-791b39eac746", // added per discussion in the RepoFlow pull request: https://github.com/rust-unofficial/awesome-rust/pull/2054
     ].iter().map(|s| s.to_string()).collect();
 }
 


### PR DESCRIPTION
RepoFlow is a modern repository platform that can host Rust crate registries and proxy crates.io. It also supports formats like Docker, PyPI, Maven, npm, and RubyGems. Available as a cloud or self-hosted solution.

This entry was added alphabetically under the Registries section and meets the contribution guidelines for popularity and maintenance.

Public documentation: https://docs.repoflow.io
Official website: https://www.repoflow.io
