### PR TITLE
Add rkik to Applications section

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ If you want to contribute, please read [this](CONTRIBUTING.md).
 * [Pijul](https://pijul.org) - A patch-based distributed version control system
 * [Rauthy](https://github.com/sebadob/rauthy) - OpenID Connect Single Sign-On Identity & Access Management
 * [Rio](https://github.com/raphamorim/rio) - A hardware-accelerated GPU terminal emulator powered by WebGPU, focusing to run in desktops and browsers.
-* [rkik](https://github.com/aguacero7/rkik) [[rkik](https://crates.io/crates/rkik)] -  CLI tool designed for stateless and passive NTP inspection, just as dig or ping are for DNS and ICMP. It supports async requests and continuous monitoring. [![crates.io](https://img.shields.io/crates/v/rkik?logo=rust)](https://crates.io/crates/rkik)
+* [rkik](https://github.com/aguacero7/rkik) -  CLI tool designed for stateless and passive NTP inspection, just as dig or ping are for DNS and ICMP. It supports async requests and continuous monitoring. [![crates.io](https://img.shields.io/crates/v/rkik?logo=rust)](https://crates.io/crates/rkik)
 * [Rust Iot Platform](https://github.com/iot-ecology/rust-iot-platform) - A high-performance IoT development platform built with Rust, designed for multi-protocol support and real-time data processing. This platform supports MQTT, WebSockets (WS), TCP, and CoAP protocols, making it highly flexible for diverse IoT applications.
 * [rx](https://github.com/cloudhead/rx) - Vi inspired Modern Pixel Art Editor
 * [Ryot](https://github.com/ignisda/ryot) - A self hosted application to track media consumption, fitness, etc.

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ If you want to contribute, please read [this](CONTRIBUTING.md).
 * [Pijul](https://pijul.org) - A patch-based distributed version control system
 * [Rauthy](https://github.com/sebadob/rauthy) - OpenID Connect Single Sign-On Identity & Access Management
 * [Rio](https://github.com/raphamorim/rio) - A hardware-accelerated GPU terminal emulator powered by WebGPU, focusing to run in desktops and browsers.
-* [rkik](https://github.com/aguacero7/rkik) -  CLI tool designed for stateless and passive NTP inspection, just as dig or ping are for DNS and ICMP. It supports async requests and continuous monitoring. [![crates.io](https://img.shields.io/crates/v/rkik?logo=rust)](https://crates.io/crates/rkik)
+* [rkik](https://github.com/aguacero7/rkik) - CLI tool designed for stateless and passive NTP inspection, just as dig or ping are for DNS and ICMP. It supports async requests and continuous monitoring. [![crates.io](https://img.shields.io/crates/v/rkik?logo=rust)](https://crates.io/crates/rkik)
 * [Rust Iot Platform](https://github.com/iot-ecology/rust-iot-platform) - A high-performance IoT development platform built with Rust, designed for multi-protocol support and real-time data processing. This platform supports MQTT, WebSockets (WS), TCP, and CoAP protocols, making it highly flexible for diverse IoT applications.
 * [rx](https://github.com/cloudhead/rx) - Vi inspired Modern Pixel Art Editor
 * [Ryot](https://github.com/ignisda/ryot) - A self hosted application to track media consumption, fitness, etc.

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ If you want to contribute, please read [this](CONTRIBUTING.md).
 * [Pijul](https://pijul.org) - A patch-based distributed version control system
 * [Rauthy](https://github.com/sebadob/rauthy) - OpenID Connect Single Sign-On Identity & Access Management
 * [Rio](https://github.com/raphamorim/rio) - A hardware-accelerated GPU terminal emulator powered by WebGPU, focusing to run in desktops and browsers.
-* [rkik](https://github.com/aguacero7/rkik) -  CLI tool designed for stateless and passive NTP inspection, just as dig or ping are for DNS and ICMP. It supports async requests and continuous monitoring. ![crate](https://img.shields.io/crates/v/rkik?logo=rust)
+* [rkik](https://github.com/aguacero7/rkik) -  CLI tool designed for stateless and passive NTP inspection, just as dig or ping are for DNS and ICMP. It supports async requests and continuous monitoring. Available on [crates.io](https://crates.io/crates/rkik) ![crate](https://img.shields.io/crates/v/rkik?logo=rust) 
 * [Rust Iot Platform](https://github.com/iot-ecology/rust-iot-platform) - A high-performance IoT development platform built with Rust, designed for multi-protocol support and real-time data processing. This platform supports MQTT, WebSockets (WS), TCP, and CoAP protocols, making it highly flexible for diverse IoT applications.
 * [rx](https://github.com/cloudhead/rx) - Vi inspired Modern Pixel Art Editor
 * [Ryot](https://github.com/ignisda/ryot) - A self hosted application to track media consumption, fitness, etc.

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ If you want to contribute, please read [this](CONTRIBUTING.md).
 * [Pijul](https://pijul.org) - A patch-based distributed version control system
 * [Rauthy](https://github.com/sebadob/rauthy) - OpenID Connect Single Sign-On Identity & Access Management
 * [Rio](https://github.com/raphamorim/rio) - A hardware-accelerated GPU terminal emulator powered by WebGPU, focusing to run in desktops and browsers.
-* [aguacero7/rkik](https://github.com/aguacero7/rkik) [[rkik](https://crates.io/crates/rkik)] -  CLI tool designed for stateless and passive NTP inspection, just as dig or ping are for DNS and ICMP. It supports async requests and continuous monitoring. ![crate](https://img.shields.io/crates/v/rkik?logo=rust)
+* [rkik](https://github.com/aguacero7/rkik) [[rkik](https://crates.io/crates/rkik)] -  CLI tool designed for stateless and passive NTP inspection, just as dig or ping are for DNS and ICMP. It supports async requests and continuous monitoring. ![crate](https://img.shields.io/crates/v/rkik?logo=rust)
 * [Rust Iot Platform](https://github.com/iot-ecology/rust-iot-platform) - A high-performance IoT development platform built with Rust, designed for multi-protocol support and real-time data processing. This platform supports MQTT, WebSockets (WS), TCP, and CoAP protocols, making it highly flexible for diverse IoT applications.
 * [rx](https://github.com/cloudhead/rx) - Vi inspired Modern Pixel Art Editor
 * [Ryot](https://github.com/ignisda/ryot) - A self hosted application to track media consumption, fitness, etc.

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ If you want to contribute, please read [this](CONTRIBUTING.md).
 * [Pijul](https://pijul.org) - A patch-based distributed version control system
 * [Rauthy](https://github.com/sebadob/rauthy) - OpenID Connect Single Sign-On Identity & Access Management
 * [Rio](https://github.com/raphamorim/rio) - A hardware-accelerated GPU terminal emulator powered by WebGPU, focusing to run in desktops and browsers.
-* [rkik](https://github.com/aguacero7/rkik) [[rkik](https://crates.io/crates/rkik)] -  CLI tool designed for stateless and passive NTP inspection, just as dig or ping are for DNS and ICMP. It supports async requests and continuous monitoring. ![crate](https://img.shields.io/crates/v/rkik?logo=rust)
+* [rkik](https://github.com/aguacero7/rkik) [[rkik](https://crates.io/crates/rkik)] -  CLI tool designed for stateless and passive NTP inspection, just as dig or ping are for DNS and ICMP. It supports async requests and continuous monitoring. [![crates.io](https://img.shields.io/crates/v/rkik?logo=rust)](https://crates.io/crates/rkik)
 * [Rust Iot Platform](https://github.com/iot-ecology/rust-iot-platform) - A high-performance IoT development platform built with Rust, designed for multi-protocol support and real-time data processing. This platform supports MQTT, WebSockets (WS), TCP, and CoAP protocols, making it highly flexible for diverse IoT applications.
 * [rx](https://github.com/cloudhead/rx) - Vi inspired Modern Pixel Art Editor
 * [Ryot](https://github.com/ignisda/ryot) - A self hosted application to track media consumption, fitness, etc.

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ If you want to contribute, please read [this](CONTRIBUTING.md).
 * [Pijul](https://pijul.org) - A patch-based distributed version control system
 * [Rauthy](https://github.com/sebadob/rauthy) - OpenID Connect Single Sign-On Identity & Access Management
 * [Rio](https://github.com/raphamorim/rio) - A hardware-accelerated GPU terminal emulator powered by WebGPU, focusing to run in desktops and browsers.
+* [rkik](https://github.com/aguacero7/rkik) -  CLI tool designed for stateless and passive NTP inspection, just as dig or ping are for DNS and ICMP. It supports async requests and continuous monitoring. ![crate](https://img.shields.io/crates/v/rkik?logo=rust)
 * [Rust Iot Platform](https://github.com/iot-ecology/rust-iot-platform) - A high-performance IoT development platform built with Rust, designed for multi-protocol support and real-time data processing. This platform supports MQTT, WebSockets (WS), TCP, and CoAP protocols, making it highly flexible for diverse IoT applications.
 * [rx](https://github.com/cloudhead/rx) - Vi inspired Modern Pixel Art Editor
 * [Ryot](https://github.com/ignisda/ryot) - A self hosted application to track media consumption, fitness, etc.

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ If you want to contribute, please read [this](CONTRIBUTING.md).
 * [Pijul](https://pijul.org) - A patch-based distributed version control system
 * [Rauthy](https://github.com/sebadob/rauthy) - OpenID Connect Single Sign-On Identity & Access Management
 * [Rio](https://github.com/raphamorim/rio) - A hardware-accelerated GPU terminal emulator powered by WebGPU, focusing to run in desktops and browsers.
-* [rkik](https://github.com/aguacero7/rkik) -  CLI tool designed for stateless and passive NTP inspection, just as dig or ping are for DNS and ICMP. It supports async requests and continuous monitoring. Available on [crates.io](https://crates.io/crates/rkik) ![crate](https://img.shields.io/crates/v/rkik?logo=rust) 
+* [aguacero7/rkik](https://github.com/aguacero7/rkik) [[rkik](https://crates.io/crates/rkik)] -  CLI tool designed for stateless and passive NTP inspection, just as dig or ping are for DNS and ICMP. It supports async requests and continuous monitoring. ![crate](https://img.shields.io/crates/v/rkik?logo=rust)
 * [Rust Iot Platform](https://github.com/iot-ecology/rust-iot-platform) - A high-performance IoT development platform built with Rust, designed for multi-protocol support and real-time data processing. This platform supports MQTT, WebSockets (WS), TCP, and CoAP protocols, making it highly flexible for diverse IoT applications.
 * [rx](https://github.com/cloudhead/rx) - Vi inspired Modern Pixel Art Editor
 * [Ryot](https://github.com/ignisda/ryot) - A self hosted application to track media consumption, fitness, etc.


### PR DESCRIPTION
This PR adds [rkik](https://github.com/aguacero7/rkik) to the **Applications** section.

`rkik` is a command-line tool written in Rust for querying or comparing multiple time servers ( for now, only using the ntp protocol).  
It is also available as a library but this is not the main point of the project.
It already has 2k+ downloads on [crates.io](https://crates.io/crates/rkik)
