### PR TITLE
Add rust-rule-engine - AI-powered rule engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -981,6 +981,8 @@ See also [Are we (I)DE yet?](https://areweideyet.com/) and [Rust Tools](https://
 
 ### Artificial Intelligence
 
+* [rust-rule-engine](https://github.com/KSD-CO/rust-rule-engine) — A high-performance rule engine with AI integration, supporting GRL syntax, ML model integration, and real-time decision making.
+
 #### Genetic algorithms
 
 * [innoave/genevo](https://github.com/innoave/genevo) - Execute genetic algorithm (GA) simulations in a customizable and extensible way.


### PR DESCRIPTION
## Adding rust-rule-engine to Artificial Intelligence section

**Project**: https://github.com/KSD-CO/rust-rule-engine
**Crates.io**: https://crates.io/crates/rust-rule-engine
