### PR TITLE
Adding Sayna.ai, a self-hosted voice layer for AI Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1046,6 +1046,7 @@ See also [About Rust’s Machine Learning Community](https://medium.com/@autumn_
 #### Tooling
 
 * [BAML](https://github.com/BoundaryML/baml) - A simple prompting language for building reliable AI workflows and agents. BAML's compiler is written in Rust!
+* [SaynaAI/sayna](https://github.com/SaynaAI/sayna) - A unified voice layer for AI agents with real-time STT/TTS streaming via WebSocket and REST APIs.
 
 ### Astronomy
 


### PR DESCRIPTION
Adding [Sayna.ai](https://github.com/SaynaAI/sayna), which is a Rust-based self-hosted voice infrastructure for AI Agents. It handles everything that relates to the voice, like STT, TTS, SIP Telephony, Noise Suppression, TURN Taking, and nearly all providers for the voice. It is a great addition to the list, and a great way to get started with voice AI agents.