### PR TITLE
Add gdvm (Godot Version Manager)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1615,6 +1615,7 @@ See also [Are we game yet?](https://arewegameyet.rs)
 * Game Servers
   * [gamedig/rust-gamedig](https://github.com/gamedig/rust-gamedig) [[gamedig](https://crates.io/crates/gamedig)] - Query game servers for informations such as name, players online, max players count etc. [![Crates.io](https://img.shields.io/crates/v/gamedig.svg)](https://crates.io/crates/gamedig) [![Crates.io](https://img.shields.io/crates/d/gamedig.svg)](https://crates.io/crates/gamedig)
 * [Godot](https://godotengine.org/)
+  * [adalinesimonian/gdvm](https://github.com/adalinesimonian/gdvm) - Godot version manager for the CLI [![CI](https://github.com/adalinesimonian/gdvm/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/adalinesimonian/gdvm/actions/workflows/build-and-test.yml)
   * [godot-rust/gdext](https://github.com/godot-rust/gdext) [[gdext](https://crates.io/crates/gdext)] - Bindings to the Godot 4+ game engine [![CI](https://github.com/godot-rust/gdext/actions/workflows/full-ci.yml/badge.svg)](https://github.com/godot-rust/gdext/actions/workflows/full-ci.yml)
   * [godot-rust/gdnative](https://github.com/godot-rust/gdnative) [[gdnative](https://crates.io/crates/gdnative)] - Bindings to the Godot 3+ game engine [![CI](https://github.com/godot-rust/gdnative/actions/workflows/full-ci.yml/badge.svg)](https://github.com/godot-rust/gdnative/actions/workflows/full-ci.yml)
 * Minecraft


### PR DESCRIPTION
We've recently surpassed 50 stars at [gdvm](https://github.com/adalinesimonian/gdvm) (54 at the time of this PR), and so I'm excited to be able to request gdvm's inclusion in awesome-rust!

gdvm is a CLI-based version manager for the Godot game engine. It fits many use cases, from launching the correct version of Godot for a project on your local machine, to use in CI, running tests for an integration against different versions of Godot. It supports Windows, macOS, and Linux on x86, x86_64, and ARM64.