### PR TITLE
Add RustAPI to the list of HTTP server tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -709,6 +709,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 * [thecoshman/http](https://github.com/thecoshman/http) - Host These Things Please - A basic http server for hosting a folder fast and simply
 * [TheWaWaR/simple-http-server](https://github.com/TheWaWaR/simple-http-server) - simple static http server
 * [vproxy/0x676e67](https://github.com/0x676e67/vproxy) - An fast asynchronous Rust HTTP/Socks5 Proxy
+* [RustAPI](https://github.com/Tuntii/RustAPI) - A DX-first, FastAPI-like web framework for Rust that provides automatic Swagger UI documentation and declarative validation out of the box
 
 ### Workflow Automation
 


### PR DESCRIPTION
### Description

I would like to add RustAPI to the Web Server section

RustAPI is an ergonomic, high-performance web framework designed to bring the developer experience of FastAPI to the Rust ecosystem.

**Key Features:**

1. FastAPI-like DX: Minimal boilerplate with intuitive attribute macros (#[get], #[post]) and type-safe extractors.
2. Automatic OpenAPI & Swagger UI: Generates OpenAPI 3.x specifications automatically and serves a built-in Swagger UI (with zero external CDN dependencies).
3. Declarative Schema Validation: Robust, type-safe request validation using simple Rust attributes.
4. Zero-Config JSON Schemas: Automatic extraction of JSON schemas from your Rust structs.
5. Performance-First: Built on top of hyper and tokio for safety and extreme concurrency.
6. Modular Architecture: Features like Swagger UI are optional and gated behind feature flags to keep production binaries lean.
7. This pull request adds a new project to the list of Rust HTTP servers in the `README.md`. The new entry highlights `RustAPI`, a FastAPI-like web framework for Rust that offers automatic Swagger UI documentation and declarative validation.
