### PR TITLE
Add diesel-guard to ORM in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1416,6 +1416,7 @@ See also [About Rust’s Machine Learning Community](https://medium.com/@autumn_
 * OGM [[ogm](https://crates.io/keywords/ogm)]
     * [Aragog](https://gitlab.com/qonfucius/aragog) [[aragog](https://crates.io/crates/aragog)] - A Lightweight ArangoDB Object document, relational and graph mapper [![pipeline status](https://gitlab.com/qonfucius/aragog/badges/master/pipeline.svg)](https://gitlab.com/qonfucius/aragog/-/commits/master)
 * ORM [[orm](https://crates.io/keywords/orm)]
+  * [ayarotsky/diesel-guard](https://github.com/ayarotsky/diesel-guard) - a linter for Diesel and SQLx that catches dangerous PostgreSQL migrations (table locks, rewrites, blocking ops) and suggests safe alternatives [![crate](https://img.shields.io/crates/v/diesel-guard.svg)](https://crates.io/crates/diesel-guard)
   * [diesel-rs/diesel](https://github.com/diesel-rs/diesel) - an ORM and Query builder
   * [ivanceras/rustorm](https://github.com/ivanceras/rustorm) - an ORM
   * [njord](https://github.com/njord-rs/njord) - ⛵ A versatile, feature-rich Rust ORM [![build status](https://github.com/njord-rs/njord/actions/workflows/core.yml/badge.svg)](https://github.com/njord-rs/njord/actions/workflows/core.yml) ![crates.io](https://img.shields.io/crates/v/njord.svg)


### PR DESCRIPTION
A linter that catches dangerous PostgreSQL migrations before they take down production:
- Detects operations that lock tables or cause downtime
- Provides safe alternatives for each blocking operation
- Works with both Diesel and SQLx migration frameworks
- Supports safety-assured blocks for verified operations