### PR TITLE
Add VelesDB to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ If you want to contribute, please read [this](CONTRIBUTING.md).
 * [Turso](https://github.com/tursodatabase/turso) - Turso Database is an in-process SQL database, compatible with SQLite.
 * [USearch](https://github.com/unum-cloud/usearch) - Similarity Search Engine for Vectors and Strings [![crates.io](https://img.shields.io/crates/v/usearch.svg)](https://crates.io/crates/usearch)
 * [valentinus](https://github.com/kn0sys/valentinus) - Next generation vector database built with LMDB bindings [![Crates.io Version](https://img.shields.io/crates/v/valentinus)](https://crates.io/crates/valentinus)
+* [VelesDB](https://github.com/cyberlife-coder/VelesDB) — Embedded vector database with 70µs search (700x faster than pgvector), ≥95% recall guaranteed, native HNSW with AVX-512/NEON SIMD, full ecosystem integrations and more.
 * [vorot93/libmdbx-rs](https://github.com/vorot93/libmdbx-rs) [[mdbx-sys](https://crates.io/crates/mdbx-sys)] - Bindings for MDBX, a "fast, compact, powerful, embedded, transactional key-value database, with permissive license". This is a fork of mozilla/lmdb-rs with patches to make it work with libmdbx.
 * [WooriDB](https://github.com/naomijub/wooridb) - General purpose time serial database inspired by Crux and Datomic.
 


### PR DESCRIPTION
# Pull Request: Add VelesDB to the list

## Title
Add VelesDB to the list

## Description

Hello! I would like to add VelesDB to the Database section.

**VelesDB** is an embedded vector database written in Rust (ELv2 licensed).

### Key features

- HNSW-based vector search with SIMD acceleration (AVX-512/AVX2/NEON)
- Hybrid BM25 + vector search
- 70µs p50 search latency
- WAL persistence
- REST API server

### Installation

```bash
cargo install velesdb-cli
cargo install velesdb-server
cargo add velesdb-core  # as library
```

### Ecosystem

- `pip install velesdb` — Python bindings
- `pip install langchain-velesdb` — LangChain integration  
- `pip install llama-index-vector-stores-velesdb` — LlamaIndex integration
- `npm i @wiscale/velesdb` — TypeScript SDK
- `cargo add tauri-plugin-velesdb` — Tauri plugin

Documentation: https://deepwiki.com/cyberlife-coder/VelesDB

I have placed it in alphabetical order.

Thanks for maintaining this list!
