### PR TITLE
Add Cocoa-Way - macOS Wayland compositor

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,6 +535,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 * [buster/rrun](https://github.com/buster/rrun) - A command launcher for Linux, similar to gmrun
 * [cantino/mcfly](https://github.com/cantino/mcfly) - Fly through your shell history. Great Scott!
 * [ChurchTao/clipboard-rs](https://github.com/ChurchTao/clipboard-rs) [[clipboard-rs](https://crates.io/crates/clipboard-rs)] - Cross-platform library written in Rust for getting and setting and monitoring changes the system-level clipboard content.
+* [Cocoa-Way](https://github.com/J-x-Z/cocoa-way) [[homebrew](https://github.com/J-x-Z/homebrew-tap)] - Native macOS Wayland compositor for running Linux GUI apps without VM overhead. Built with Smithay. [![build badge](https://github.com/J-x-Z/cocoa-way/actions/workflows/release.yml/badge.svg)](https://github.com/J-x-Z/cocoa-way/actions)
 * [crabz](https://github.com/sstadick/crabz) - Multi-threaded compression and decompression CLI tool [![Build Status](https://github.com/sstadick/crabz/workflows/Check/badge.svg)](https://github.com/sstadick/crabz/actions?query=workflow%3ACheck)
 * [cristianoliveira/funzzy](https://github.com/cristianoliveira/funzzy) - A configurable filesystem watcher inspired by [entr](http://eradman.com/entrproject/)
 * [dalance/procs](https://github.com/dalance/procs) - A modern replacement for 'ps' [![Regression](https://github.com/dalance/procs/actions/workflows/regression.yml/badge.svg)](https://github.com/dalance/procs/actions/workflows/regression.yml)


### PR DESCRIPTION
Add Cocoa-Way, a native macOS Wayland compositor that enables running Linux GUI applications on macOS via waypipe without VM overhead.

**Why it's valuable:**
- Unique: Only native macOS Wayland compositor written in Rust
- Practical: Enables seamless Linux app usage on Mac (with OrbStack, Docker, SSH)
- Research-backed: Part of protocol virtualization research
- Active: Regular updates and maintenance
- Uses Smithay as the compositor framework

**Entry added to:** Applications > System tools (alphabetically sorted)

**Links:**
- Repository: https://github.com/J-x-Z/cocoa-way
- Homebrew: https://github.com/J-x-Z/homebrew-tap
- Demo video: https://youtu.be/VS3vQp5i8YQ