### PR TITLE
Add try-rs to the list of tools in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,6 +477,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 * [mediar-ai/screenpipe](https://github.com/mediar-ai/screenpipe) - 24/7 local AI screen & mic recording. Build AI apps that have the full context. Works with Ollama.
 * [pier-cli/pier](https://github.com/pier-cli/pier) - A central repository to manage (add, search metadata, etc.) all your one-liners, scripts, tools, and CLIs
 * [ShadoySV/work-break](https://github.com/ShadoySV/work-break) [[work-break](https://crates.io/crates/work-break)] - Work and rest time balancer taking into account your current and today strain [![Build](https://github.com/ShadoySV/work-break/actions/workflows/release.yml/badge.svg)](https://github.com/ShadoySV/work-break/actions/workflows/release.yml)
+* [tassiovirginio/try-rs](https://github.com/tassiovirginio/try-rs) [[try-rs](https://crates.io/crates/try-rs)] - Workspace manager CLI with a TUI to organize and navigate temporary experiments.
 * [yashs662/rust_kanban](https://github.com/yashs662/rust_kanban) [[rust-kanban](https://crates.io/crates/rust-kanban)] [![Build](https://github.com/yashs662/rust_kanban/actions/workflows/build.yml/badge.svg)](https://github.com/yashs662/rust_kanban/releases) - A Kanban App for the terminal
 
 ### Routing protocols


### PR DESCRIPTION
Hello, and thank you for maintaining this list.

This PR adds **try-rs** to the *Applications → Productivity* section.

**try-rs** is a Rust-based workspace manager CLI with a TUI designed to help developers organize, navigate, and manage temporary experiments and throwaway projects, improving productivity during prototyping and exploration.

The project meets the objective inclusion criteria defined in `CONTRIBUTING.md`, as it currently has over **130 GitHub stars**, exceeding the minimum threshold required for new entries.

Thank you for your time and for reviewing this contribution.