### PR TITLE
Add mcp-gateway to AI Tooling section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1074,6 +1074,7 @@ See also [About Rust’s Machine Learning Community](https://medium.com/@autumn_
 
 * [BAML](https://github.com/BoundaryML/baml) - A simple prompting language for building reliable AI workflows and agents. BAML's compiler is written in Rust!
 * [Cortex Memory](https://github.com/sopaco/cortex-mem) - A complete solution for agent memory, from extraction and vector search to automated optimization, and insights dashboard out-of-the-box.
+* [mcp-gateway](https://github.com/MikkoParkkola/mcp-gateway) - Universal Model Context Protocol (MCP) gateway with Meta-MCP pattern for ~95% token savings, circuit breakers, and rate limiting. [![crates.io](https://img.shields.io/crates/v/mcp-gateway.svg)](https://crates.io/crates/mcp-gateway)
 
 ### Astronomy
 


### PR DESCRIPTION
## Addition

**mcp-gateway** - Universal Model Context Protocol (MCP) gateway

### Details

- **Repository**: https://github.com/MikkoParkkola/mcp-gateway
- **Crates.io**: https://crates.io/crates/mcp-gateway
- **Language**: Pure Rust

### Why it belongs in AI Tooling

MCP (Model Context Protocol) is Anthropic's open standard for connecting AI assistants to external tools. mcp-gateway provides:

- Meta-MCP pattern: 4 tools → access 100+ tools dynamically
- ~95% context token savings for LLMs
- Production failsafes: circuit breakers, retry, rate limiting
- 42 starter API capabilities included

### Section

Added to **Artificial Intelligence > Tooling** in alphabetical order.