### PR TITLE
Add rust-monorepo-analyzer (rma-cli) to Security tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 * [arp-scan-rs](https://github.com/kongbytes/arp-scan-rs) - A minimalistic ARP scan tool for fast local network scans
 * [biandratti/huginn-net](https://github.com/biandratti/huginn-net) - Multi-protocol passive network fingerprinting combining p0f TCP and JA4 TLS analysis for OS and application detection [![CI](https://github.com/biandratti/huginn-net/actions/workflows/ci.yml/badge.svg)](https://github.com/biandratti/huginn-net/actions/workflows/ci.yml)
 * [bountyyfi/lonkero](https://github.com/bountyyfi/lonkero) - Enterprise-grade web vulnerability scanner with 60+ attack modules for penetration testing and security assessments
+* [bumahkib7/rust-monorepo-analyzer](https://github.com/bumahkib7/rust-monorepo-analyzer) [[rma-cli](https://crates.io/crates/rma-cli)] - Fast SAST scanner that compiles Semgrep rules to native tree-sitter matchers. 647+ rules, 28 languages. [![build badge](https://github.com/bumahkib7/rust-monorepo-analyzer/actions/workflows/ci.yml/badge.svg)](https://github.com/bumahkib7/rust-monorepo-analyzer/actions/workflows/ci.yml)
 * [cargo-audit](https://crates.io/crates/cargo-audit) - Audit Cargo.lock for crates with security vulnerabilities
 * [cargo-auditable](https://crates.io/crates/cargo-auditable) - Make production Rust binaries auditable
 * [cargo-crev](https://crates.io/crates/cargo-crev) - A cryptographically verifiable code review system for the cargo package manager.


### PR DESCRIPTION
## Summary
Add [rust-monorepo-analyzer](https://github.com/bumahkib7/rust-monorepo-analyzer) (rma-cli) to the Security tools section.

## About rma-cli
A fast SAST (Static Application Security Testing) scanner written in Rust that compiles Semgrep rules to native tree-sitter matchers for significantly faster scanning.

**Key features:**
- 647+ security rules covering OWASP Top 10, CWE, and more
- Supports 28 programming languages
- Native tree-sitter parsing for fast, accurate AST matching
- SARIF/JSON output for CI/CD integration

**Links:**
- GitHub: https://github.com/bumahkib7/rust-monorepo-analyzer
- Crates.io: https://crates.io/crates/rma-cli
- License: MIT/Apache-2.0

## Checklist
- [x] Tool is written in Rust
- [x] Published on crates.io
- [x] Has CI workflow (passing)
- [x] Follows the list format with crates.io link and build badge
- [x] Placed in alphabetical order within Security tools section