### PR TITLE
Add lamco-rdp-server to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -658,6 +658,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 * [gitlogue](https://github.com/unhappychoice/gitlogue) - A TUI screensaver that visualizes Git commit history in your terminal
 * [guoxbin/dtool](https://github.com/guoxbin/dtool) - A useful command-line tool collection to assist development including conversion, codec, hashing, encryption, etc.
 * [Linus-Mussmaecher/rucola](https://github.com/Linus-Mussmaecher/rucola) - Terminal-based markdown note manager. [![Crate](https://img.shields.io/crates/v/rucola-notes.svg?logo=rust)](https://crates.io/crates/rucola-notes) [![Build Status](https://github.com/Linus-Mussmaecher/rucola/actions/workflows/continuous-testing.yml/badge.svg)](https://github.com/Linus-Mussmaecher/rucola/actions/workflows/continuous-testing.yml)
+* [lamco-admin/lamco-rdp-server](https://github.com/lamco-admin/lamco-rdp-server) - A native Wayland RDP server built on IronRDP with H.264/EGFX encoding and multiple capture backends.
 * [Mobslide](https://github.com/thewh1teagle/mobslide) - Desktop application that turns your smartphone into presentation remote controller.
 * [mprocs](https://github.com/pvolok/mprocs) - TUI for running multiple processes
 * [mrjackwills/oxker](https://github.com/mrjackwills/oxker) [[oxker](https://crates.io/crates/oxker)] - A simple tui to view & control docker containers.


### PR DESCRIPTION
Adds [lamco-admin/lamco-rdp-server](https://github.com/lamco-admin/lamco-rdp-server) to the Utilities section.

lamco-rdp-server is a native Wayland RDP server built on IronRDP with H.264/EGFX encoding and multiple capture backends (PipeWire, wlr-screencopy, KDE portal). It provides RDP access to Wayland desktops that lack native RDP server support.

- Placed alphabetically in the Utilities section
- Follows the contribution template format