### PR TITLE
Add link to hud for Tokio runtime profiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -954,6 +954,7 @@ See also [Are we (I)DE yet?](https://areweideyet.com/) and [Rust Tools](https://
 * [Bencher](https://github.com/bencherdev/bencher) - A suite of continuous benchmarking tools designed to catch performance regressions in CI
 * [bheisler/criterion.rs](https://github.com/bheisler/criterion.rs) - Statistics-driven benchmarking library
 * [Bytehound](https://github.com/koute/bytehound) - A memory profiler for Linux
+* [cong-or/hud](https://github.com/cong-or/hud) - Find what's blocking your Tokio runtime. Zero-instrumentation eBPF profiler.
 * [Divan](https://github.com/nvzqz/divan) - Simple yet powerful benchmarking library with allocation profiling
 * [ellisonch/rust-stopwatch](https://github.com/ellisonch/rust-stopwatch) - A stopwatch library
 * FlameGraphs


### PR DESCRIPTION
Add hud to Development tools > Profiling.

It is a zero-instrumentation eBPF profiler for Tokio runtimes.
Meets the criteria (>50 stars).