### PR TITLE
Add pdf_oxide to Libraries > Graphics > PDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -1707,6 +1707,7 @@ See also [Are we game yet?](https://arewegameyet.rs)
   * [fschutt/printpdf](https://github.com/fschutt/printpdf) - PDF writing library
   * [J-F-Liu/lopdf](https://github.com/J-F-Liu/lopdf) - PDF document manipulation
   * [kaj/rust-pdf](https://github.com/kaj/rust-pdf) - Generating PDF files in pure Rust
+  * [yfedoseev/pdf_oxide](https://github.com/yfedoseev/pdf_oxide) [[pdf_oxide](https://crates.io/crates/pdf_oxide)] - Fast PDF toolkit for text extraction, image extraction, markdown conversion, creation, and editing. Python bindings via PyO3.
 * [Vulkan](https://www.vulkan.org/) [[vulkan](https://crates.io/keywords/vulkan)]
   * [erupt](https://gitlab.com/Friz64/erupt) [[erupt](https://crates.io/crates/erupt)] - [![build badge](https://gitlab.com/Friz64/erupt/badges/main/pipeline.svg)](https://gitlab.com/Friz64/erupt/-/pipelines)
   * [vulkano](https://github.com/vulkano-rs/vulkano) [[vulkano](https://crates.io/crates/vulkano)] - Safe and rich Rust wrapper around the Vulkan API


### PR DESCRIPTION
## Summary

Add [pdf_oxide](https://github.com/yfedoseev/pdf_oxide) to the PDF subsection under Libraries > Graphics.

pdf_oxide is a fast PDF toolkit written in pure Rust. It supports text extraction, image extraction, markdown conversion, PDF creation, and editing. Also provides Python bindings via PyO3.

**Key facts:**
- Pure Rust — no C/C++ dependencies for core functionality
- MIT / Apache-2.0 dual-licensed
- 99.8% pass rate verified against 3,830 PDFs (veraPDF, Mozilla pdf.js, SafeDocs)
- Mean 2.3ms per page extraction latency
- Python bindings via PyO3 (published on PyPI)

**Links:**
- GitHub: https://github.com/yfedoseev/pdf_oxide
- Crates.io: https://crates.io/crates/pdf_oxide
- Docs: https://docs.rs/pdf_oxide