### PR TITLE
Add 'cc-switch' to Productivity and 'pgdog' to Database applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ If you want to contribute, please read [this](CONTRIBUTING.md).
 * [oxigraph/oxigraph](https://github.com/oxigraph/oxigraph) [[oxigraph](https://crates.io/crates/oxigraph)] - graph database implementing the [SPARQL](https://www.w3.org/TR/sparql11-overview/) standard ![Crates.io Version](https://img.shields.io/crates/v/oxigraph?logo=Rust)
 * [ParadeDB](https://github.com/paradedb/paradedb/) - ParadeDB is an Elasticsearch alternative built on Postgres, designed for real-time search and analytics.
 * [ParityDB](https://github.com/paritytech/parity-db) - Fast and reliable database, optimised for read operation
+* [pgdogdev/pgdog](https://github.com/pgdogdev/pgdog) - A fast proxy for scaling PostgreSQL with connection pooling, load balancing, and sharding.
 * [PumpkinDB](https://github.com/PumpkinDB/PumpkinDB) - an event sourcing database engine
 * [Qdrant](https://github.com/qdrant/qdrant) - An open source vector similarity search engine with extended filtering support [![Tests](https://github.com/qdrant/qdrant/actions/workflows/rust.yml/badge.svg)](https://github.com/qdrant/qdrant/actions)
 * [Qrlew/qrlew](https://github.com/Qrlew/qrlew) [[qrlew](https://crates.io/crates/qrlew)] - The SQL-to-SQL Differential Privacy layer [![Qrlew](https://github.com/Qrlew/qrlew/actions/workflows/ci.yml/badge.svg)](https://github.com/Qrlew/qrlew/actions) ![Crates.io Version](https://img.shields.io/crates/v/qrlew?logo=Rust)


### PR DESCRIPTION
Add [cc-switch](https://github.com/farion1231/cc-switch) to Applications > Productivity.

It is a Tauri-based (Rust backend) all-in-one GUI assistant and profile manager for AI CLI tools like Claude Code, Codex, and Gemini CLI.
Meets the criteria (>50 stars).

---
Add [PgDog](https://github.com/pgdogdev/pgdog) to Applications > Database.

It is a fast, Rust-based proxy for scaling PostgreSQL that supports connection pooling, load balancing, and sharding.
Meets the criteria (>50 stars).