### PR TITLE
Add tortuise: terminal Gaussian Splatting 3D viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,7 @@ See also [Games Made With Piston](https://github.com/PistonDevelopers/piston/wik
 
 ### Graphics
 
+* [buildoak/tortuise](https://github.com/buildoak/tortuise) - Terminal Gaussian Splatting 3D viewer. 6 render modes, CPU-only, crossterm + rayon.
 * [dps/rust-raytracer](https://github.com/dps/rust-raytracer) - An implementation of a very simple raytracer based on Ray Tracing in One Weekend by Peter Shirley.
 * [flxzt/rnote](https://github.com/flxzt/rnote) - Sketch and take handwritten notes.
 * [ivanceras/svgbob](https://github.com/ivanceras/svgbob) - converts ASCII diagrams into SVG graphics


### PR DESCRIPTION
tortuise renders Gaussian Splats in the terminal using Unicode characters. 6 render modes, CPU-only, built with crossterm + rayon. 84 stars.