### PR TITLE
Add vtracer for raster to vector graphics conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,7 +403,6 @@ See also [Games Made With Piston](https://github.com/PistonDevelopers/piston/wik
 
 ### Graphics
 
-* [buildoak/tortuise](https://github.com/buildoak/tortuise) - Terminal Gaussian Splatting 3D viewer. 6 render modes, CPU-only, crossterm + rayon.
 * [dps/rust-raytracer](https://github.com/dps/rust-raytracer) - An implementation of a very simple raytracer based on Ray Tracing in One Weekend by Peter Shirley.
 * [flxzt/rnote](https://github.com/flxzt/rnote) - Sketch and take handwritten notes.
 * [ivanceras/svgbob](https://github.com/ivanceras/svgbob) - converts ASCII diagrams into SVG graphics


### PR DESCRIPTION
Add [VTracer](https://github.com/visioncortex/vtracer) to Applications > Image processing.

It is a fast and robust open-source software (and library) to convert raster images into vector graphics. Meets the criteria (>50 stars).