### PR TITLE
Add mdbook-linkcheck to Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ If you want to contribute, please read [this](CONTRIBUTING.md).
 * [MaidSafe](https://github.com/maidsafe) - A decentralized platform.
 * [mdBook](https://github.com/rust-lang/mdBook) - A command line utility to create books from markdown files [![Build Status](https://github.com/rust-lang/mdBook/actions/workflows/main.yml/badge.svg)](https://github.com/rust-lang/mdBook/actions)
 * [Mega](https://github.com/web3infra-foundation/mega) - A monorepo & monolithic codebase management system that supports Git, also is an unofficial open source implementation of Google Piper.
+* [Michael-F-Bryan/mdbook-linkcheck](https://github.com/Michael-F-Bryan/mdbook-linkcheck) [[mdbook-linkcheck](https://crates.io/crates/mdbook-linkcheck)] - A backend for mdbook which will check your links for you.
 * [mirrord](https://github.com/metalbear-co/mirrord) - Connect your local process and your cloud environment, and run local code in cloud conditions
 * [nicohman/eidolon](https://github.com/nicohman/eidolon) - A steam and drm-free game registry and launcher for linux and macosx
 * [Pijul](https://pijul.org) - A patch-based distributed version control system


### PR DESCRIPTION
Add [mdbook-linkcheck](https://github.com/Michael-F-Bryan/mdbook-linkcheck) to Applications.

It is a widely used backend for `mdbook` that validates URLs/links.
Meets the criteria (>50 stars).