### PR TITLE
Add Inkwell to Text editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -635,6 +635,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 * [gchp/iota](https://github.com/gchp/iota) - A simple text editor
 * [helix](https://github.com/helix-editor/helix) - A post-modern modal text editor inspired by Neovim/Kakoune. [![build badge](https://github.com/helix-editor/helix/actions/workflows/build.yml/badge.svg)](https://github.com/helix-editor/helix/actions)
 * [ilai-deutel/kibi](https://github.com/ilai-deutel/kibi) - A tiny (≤1024 LOC) text editor with syntax highlighting, incremental search and more. [![build badge](https://github.com/ilai-deutel/kibi/actions/workflows/ci.yml/badge.svg)](https://github.com/ilai-deutel/kibi/actions?query=branch%3Amaster)
+* [Inkwell](https://github.com/4worlds4w-svg/inkwell) - A portable, offline-first Markdown editor built with Tauri v2. Single executable, zero telemetry.
 * [Lapce](https://github.com/lapce/lapce) - A modern editor with a backend. Taking inspiration from the discontinued [xi-editor](https://github.com/xi-editor/xi-editor).
 * [mathall/rim](https://github.com/mathall/rim) - Vim-like text editor.
 * [ox](https://github.com/curlpipe/ox) - An independent Rust text editor that runs in your terminal!


### PR DESCRIPTION
Add [Inkwell](https://github.com/4worlds4w-svg/inkwell) to the Text editors section.

Inkwell is a portable, offline-first Markdown editor built with Rust and Tauri v2.

- **58 stars** on GitHub (meets the 50-star threshold)
- Single executable (~3MB), no install required
- Zero telemetry, fully offline, data stays local
- Live preview, syntax highlighting, multiple themes
- Cross-platform: Windows, macOS, Linux

Placed alphabetically in **Text editors**.