### PR TITLE
Add noodles to Bioinformatics section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1167,9 +1167,9 @@ See also [About Rust’s Machine Learning Community](https://medium.com/@autumn_
 
 ### Bioinformatics
 
-* [zaeleus/noodles](https://github.com/zaeleus/noodles) [[noodles](https://crates.io/crates/noodles)] - Bioinformatics I/O libraries in Rust [![build badge](https://github.com/zaeleus/noodles/workflows/CI/badge.svg)](https://github.com/zaeleus/noodles/actions)
 * [polars-bio](https://github.com/biodatageeks/polars-bio) - Blazing-Fast Bioinformatic Operations on Python DataFrames ![PyPI - Version](https://img.shields.io/pypi/v/polars-bio)
 * [Rust-Bio](https://github.com/rust-bio) - bioinformatics libraries.
+* [zaeleus/noodles](https://github.com/zaeleus/noodles) [[noodles](https://crates.io/crates/noodles)] - Bioinformatics I/O libraries in Rust [![build badge](https://github.com/zaeleus/noodles/workflows/CI/badge.svg)](https://github.com/zaeleus/noodles/actions)
 
 ### Caching
 


### PR DESCRIPTION
Adds [zaeleus/noodles](https://github.com/zaeleus/noodles) to the Bioinformatics section under Libraries.

**noodles** is a Rust library providing I/O support for common bioinformatics file formats — including BAM, CRAM, SAM, VCF, BCF, GFF, BED, FASTA, FASTQ, and more. It is the most comprehensive bioinformatics I/O library in the Rust ecosystem.

- 655 GitHub stars
- 370,000+ crates.io downloads (well above the 2,000 threshold)
- MIT license
- Actively maintained (last commit today)
- Placed alphabetically before polars-bio in the Bioinformatics section