### PR TITLE
Add wreq-ruby to FFI / Ruby section

### DIFF
--- a/README.md
+++ b/README.md
@@ -919,6 +919,7 @@ See also [Foreign Function Interface](https://doc.rust-lang.org/book/first-editi
 * Ruby
   * [d-unsed/ruru](https://github.com/d-unsed/ruru) - native Ruby extensions written in Rust
   * [danielpclark/rutie](https://github.com/danielpclark/rutie) - native Ruby extensions written in Rust and vice versa
+  * [SearchApi/wreq-ruby](https://github.com/SearchApi/wreq-ruby) - Ruby HTTP client with browser TLS/HTTP2 fingerprinting, powered by wreq
 * Web Assembly
   * [rhysd/wain](https://github.com/rhysd/wain) - wain: WebAssembly INterpreter from scratch in Safe Rust with zero dependency [![build badge](https://github.com/rhysd/wain/workflows/CI/badge.svg?branch=master&event=push)](https://github.com/rhysd/wain/actions?query=workflow%3ACI+branch%3Amaster+event%3Apush)
   * [wasm-bindgen](https://github.com/wasm-bindgen/wasm-bindgen) - A project for facilitating high-level interactions between wasm modules and JS.


### PR DESCRIPTION
wreq-ruby is the first production-ready Ruby HTTP client with real browser TLS/HTTP2 fingerprinting — and it's powered by Rust.

Ruby has never had a library capable of emulating browser TLS and HTTP2 fingerprints. Every existing Ruby HTTP library relies on OpenSSL, which provides no control over TLS extension ordering, cipher suite ordering, or HTTP/2 frame settings. Python, Go, and Node have had solutions for this. Thanks to the wreq crate (403k+ downloads), Ruby now does too.

wreq-ruby wraps the wreq crate via FFI with pre-compiled native gems for Linux and macOS, so Ruby developers don't need a Rust toolchain. It's used in production at SearchApi and actively maintained.