### PR TITLE
Add git-ai to System tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,6 +571,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 * [fish-shell/fish-shell](https://github.com/fish-shell/fish-shell) - The user-friendly command line shell
 * [fork](https://github.com/immortal/fork) - Library for creating a new process detached from the controlling terminal (daemon)
 * [fselect](https://crates.io/crates/fselect) - Find files with SQL-like queries
+* [git-ai-project/git-ai](https://github.com/git-ai-project/git-ai) - A git extension that tracks AI-generated code in your repositories, linking lines to the agent, model, and transcripts.
 * [gitbutlerapp/gitbutler](https://github.com/gitbutlerapp/gitbutler) - A modern Git-based version control interface with both a GUI and CLI built from the ground up for AI-powered workflows.
 * [gitui](https://github.com/gitui-org/gitui) - Blazing fast terminal client for git. [![build](https://github.com/gitui-org/gitui/actions/workflows/ci.yml/badge.svg)](https://github.com/gitui-org/gitui/actions)
 * [GQL](https://github.com/amrdeveloper/gql) - A SQL like query language to run on .git files.


### PR DESCRIPTION
Add [git-ai](https://github.com/git-ai-project/git-ai) to Applications > System tools.

It is an open-source git extension written in Rust that tracks AI-generated code in repositories, linking every AI-written line to the agent and model.
Meets the criteria (>50 stars).