### PR TITLE
Add tunnelto to Web applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -719,6 +719,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 
 ### Web
 
+* [agrinman/tunnelto](https://github.com/agrinman/tunnelto) [[tunnelto](https://crates.io/crates/tunnelto)] - Lets you expose your locally running web server via a public URL.
 * [cfal/tobaru](https://github.com/cfal/tobaru) - Port forwarder with allowlists, IP and TLS SNI/ALPN rule-based routing, iptables support, round-robin forwarding (load balancing), and hot reloading.
 * [importantimport/hatsu](https://github.com/importantimport/hatsu) - 🩵 Self-hosted and fully-automated ActivityPub bridge for static sites. [![release](https://github.com/importantimport/hatsu/actions/workflows/release.yml/badge.svg)](https://github.com/importantimport/hatsu/actions/workflows/release.yml)
 * [LemmyNet/lemmy](https://github.com/LemmyNet/lemmy) - A link aggregator / reddit clone for the fediverse [![Build Status](https://cloud.drone.io/api/badges/LemmyNet/lemmy/status.svg)](https://cloud.drone.io/LemmyNet/lemmy)


### PR DESCRIPTION
Add [tunnelto](https://github.com/agrinman/tunnelto) to Applications > Web.

It is a tool written in Rust that lets you expose your locally running web server via a public URL (an open-source alternative to ngrok).
Meets the criteria (>50 stars).