### PR TITLE
Add nautilus_trader to Finance applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,7 @@ See also [crates matching keyword 'emulator'](https://crates.io/keywords/emulato
 See also [Payments](#payments) applications.
 
 * [klirr](https://github.com/Sajjon/klirr) [[klirr](https://crates.io/crates/klirr)] - Zero-maintenance and smart FOSS generating beautiful invoices for services and expenses.
+* [nautechsystems/nautilus_trader](https://github.com/nautechsystems/nautilus_trader) - A high-performance, production-grade algorithmic trading platform written in Rust and Python.
 * [tackler](https://github.com/tackler-ng/tackler) [[tackler](https://crates.io/crates/tackler)] - Fast, reliable bookkeeping engine with native GIT SCM support for plain text accounting [![CI Badge](https://github.com/tackler-ng/tackler/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/tackler-ng/tackler/blob/main/.github/workflows/ci.yml)
 * [tarkah/tickrs](https://github.com/tarkah/tickrs) - Realtime ticker data in your terminal
 


### PR DESCRIPTION
Add [NautilusTrader](https://github.com/nautechsystems/nautilus_trader) to Applications > Finance.

It is a high-performance algorithmic trading platform with core components written in Rust (and Python bindings via PyO3/Cython), supporting both backtesting and live trading.
Meets the criteria (>50 stars).