### PR TITLE
Add grpc-php-rs to FFI > PHP

### DIFF
--- a/README.md
+++ b/README.md
@@ -916,6 +916,7 @@ See also [Foreign Function Interface](https://doc.rust-lang.org/book/first-editi
 * Objective-C
   * [SSheldon/rust-objc](https://github.com/SSheldon/rust-objc) - Objective-C Runtime bindings and wrapper for Rust
 * PHP
+  * [grpc-php-rs](https://github.com/BSN4/grpc-php-rs) - Drop-in replacement for the PHP gRPC extension, built with tonic and rustls
   * [phper-framework/phper](https://github.com/phper-framework/phper) - The framework that allows us to write PHP extensions using pure and safe Rust whenever possible
 * Prolog
   * [mthom/scryer-prolog](https://github.com/mthom/scryer-prolog/) - Scryer Prolog is a free software ISO Prolog system written in Rust


### PR DESCRIPTION
Adds [grpc-php-rs](https://github.com/BSN4/grpc-php-rs) to the FFI > PHP section — a drop-in replacement for the PHP gRPC extension, built with tonic and rustls via ext-php-rs bindings.

First Rust-based PHP extension published on [PIE](https://github.com/php/pie) with pre-built binaries.