### PR TITLE
Add temps — single-binary PaaS that replaces Vercel + Plausible + Sentry + Pingdom

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ If you want to contribute, please read [this](CONTRIBUTING.md).
 * [shuttle](https://github.com/shuttle-hq/shuttle) - A serverless platform.
 * [Sniffnet](https://github.com/GyulyVGC/sniffnet) - Cross-platform application to monitor your network traffic with ease [![build badge](https://img.shields.io/github/actions/workflow/status/gyulyvgc/sniffnet/rust.yml?logo=github)](https://github.com/GyulyVGC/sniffnet/blob/main/.github/workflows/rust.yml) [![crate](https://img.shields.io/crates/v/sniffnet?logo=rust)](https://crates.io/crates/sniffnet)
 * [SWC](https://github.com/swc-project/swc) - super-fast TypeScript / JavaScript compiler
+* [temps](https://github.com/gotempsh/temps) - A self-hosted PaaS that replaces Vercel, analytics, error tracking, and uptime monitoring with a single Rust binary
 * [tiny](https://github.com/osa1/tiny) - A terminal IRC client
 * [Typst](https://github.com/typst/typst) - A markup-based typesetting system [![crates.io](https://img.shields.io/crates/v/typst.svg)](https://crates.io/crates/typst)
 * [UpVPN](https://github.com/upvpn/upvpn-app) - WireGuard VPN client for macOS, Linux, and Windows built on Tauri.


### PR DESCRIPTION
## What is temps?

[temps](https://github.com/gotempsh/temps) is a self-hosted PaaS built entirely in Rust that replaces 6+ paid SaaS tools with a single binary:

- **Deployments** (replaces Vercel/Railway) — git-push deploys with zero-downtime, Nixpacks/Dockerfile builds
- **Web Analytics** (replaces Plausible/PostHog) — privacy-first, no cookie banners
- **Session Replay** (replaces FullStory) — built-in user session recording
- **Error Tracking** (replaces Sentry) — automatic error capture and alerting
- **Uptime Monitoring** (replaces Pingdom) — health checks and incident detection
- **Managed Databases** — PostgreSQL, Redis, and more

### Why it belongs here

- **Written in Rust** — Axum 0.8, Sea-ORM, Pingora proxy, 55 workspace crates
- **225+ GitHub stars** (meets the 50-star threshold)
- **Actively maintained** — regular releases, growing community
- **Unique in the ecosystem** — no other Rust project combines deployment + observability in a single binary

Placed alphabetically in the Applications section (between SWC and tiny).