### PR TITLE
Add max-sixty/worktrunk to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,6 +496,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 * [illacloud/illa](https://github.com/illacloud/illa) - Low-code internal tool builder.
 * [kruseio/hygg](https://github.com/kruseio/hygg) [[hygg](https://crates.io/crates/hygg)] - 📚 Simplifying the way you read. Minimalistic Vim-like TUI document reader.
 * [LLDAP](https://github.com/lldap/lldap) - Simplified LDAP interface for authentication.
+* [max-sixty/worktrunk](https://github.com/max-sixty/worktrunk) [[worktrunk](https://crates.io/crates/worktrunk)] - CLI for git worktree management designed for running AI agents in parallel, with hooks, LLM commit messages, and merge workflows [![CI](https://img.shields.io/github/actions/workflow/status/max-sixty/worktrunk/ci.yaml?branch=main&logo=github)](https://github.com/max-sixty/worktrunk/actions?query=branch%3Amain+workflow%3Aci)
 * [pier-cli/pier](https://github.com/pier-cli/pier) - A central repository to manage (add, search metadata, etc.) all your one-liners, scripts, tools, and CLIs
 * [screenpipe](https://github.com/screenpipe/screenpipe) - 24/7 local AI screen & mic recording. Build AI apps that have the full context. Works with Ollama.
 * [ShadoySV/work-break](https://github.com/ShadoySV/work-break) [[work-break](https://crates.io/crates/work-break)] - Work and rest time balancer taking into account your current and today strain [![Build](https://github.com/ShadoySV/work-break/actions/workflows/release.yml/badge.svg)](https://github.com/ShadoySV/work-break/actions/workflows/release.yml)


### PR DESCRIPTION
## Summary

Adds [worktrunk](https://github.com/max-sixty/worktrunk) to the **Productivity** section.

## What is it?

Worktrunk is a CLI that makes git worktrees as easy as branches, designed
for running multiple AI coding agents (Claude Code, Codex, etc.) in parallel.
Core commands: `wt switch`, `wt list`, `wt merge`, `wt remove` — each wrapping
multi-step git operations into a single command.

## Why it qualifies

- ✅ **Stars**: 2,000+ GitHub stars (above the 50-star threshold)
- ✅ **crates.io**: Published as [`worktrunk`](https://crates.io/crates/worktrunk)