### PR TITLE
Add leptos-use to the list of Leptos utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -2101,6 +2101,7 @@ See also [Are we web yet?](https://www.arewewebyet.org) and [Rust web framework 
   * [sauron](https://github.com/ivanceras/sauron) - Client side web framework which closely adheres to The Elm Architecture.
   * [seed](https://github.com/seed-rs/seed) - A framework for creating web apps
   * [stdweb](https://crates.io/crates/stdweb) - A standard library for the client-side Web
+  * [synphonyte/leptos-use](https://github.com/synphonyte/leptos-use) [[leptos-use](https://crates.io/crates/leptos-use)] - Collection of essential Leptos utilities inspired by React-Use and VueUse, with SSR support [![Build Status](https://github.com/synphonyte/leptos-use/actions/workflows/cd.yml/badge.svg)](https://github.com/synphonyte/leptos-use/actions/workflows/cd.yml)
   * [tinyweb](https://github.com/LiveDuo/tinyweb) - A minimal Rust web framework for wasm in 800 lines of code
   * [yew](https://crates.io/crates/yew) - A framework for making client web apps
 * HTTP Client


### PR DESCRIPTION
## Summary

Adds [leptos-use](https://github.com/synphonyte/leptos-use) to the
**Libraries → Web programming → Client-side / WASM** section.

## What is it?

`leptos-use` is a collection of 89+ utility functions for Leptos,
inspired by React-Use and VueUse. It covers sensors, state, browser APIs,
animation, network, and more — all with SSR support out of the box.

## Why it qualifies

- ✅ **Stars**: 400+ GitHub stars (well above the 50-star threshold)
- ✅ **crates.io**: Published as [`leptos-use`](https://crates.io/crates/leptos-use)