### PR TITLE
Add hexyl to System tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -617,6 +617,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 * [redox-os/ion](https://github.com/redox-os/ion) - Next-generation system shell
 * [sharkdp/bat](https://github.com/sharkdp/bat) - A cat(1) clone with wings. [![CICD](https://github.com/sharkdp/bat/actions/workflows/CICD.yml/badge.svg?branch=master)](https://github.com/sharkdp/bat/actions/workflows/CICD.yml)
 * [sharkdp/fd](https://github.com/sharkdp/fd) - A simple, fast and user-friendly alternative to find. [![CICD](https://github.com/sharkdp/fd/actions/workflows/CICD.yml/badge.svg)](https://github.com/sharkdp/fd/actions/workflows/CICD.yml)
+* [sharkdp/hexyl](https://github.com/sharkdp/hexyl) [[hexyl](https://crates.io/crates/hexyl)] - A command-line hex viewer with colored output for different byte categories [![CICD](https://github.com/sharkdp/hexyl/actions/workflows/CICD.yml/badge.svg)](https://github.com/sharkdp/hexyl/actions/workflows/CICD.yml)
 * [sitkevij/hex](https://github.com/sitkevij/hex) - A colorized hexdump terminal utility.
 * [skim](https://github.com/skim-rs/skim) - A fuzzy finder
 * [supercilex/fuc](https://github.com/supercilex/fuc) - Fast `cp` and `rm` commands


### PR DESCRIPTION
## Summary

Adds [hexyl](https://github.com/sharkdp/hexyl) to the **System tools** section.

## What is it?

`hexyl` is a terminal hex viewer that uses colored output to distinguish
different categories of bytes (NULL bytes, printable ASCII, whitespace,
other ASCII, and non-ASCII). Configurable via environment variables.

## Why it qualifies

- ✅ **Stars**: 9,000+ GitHub stars (well above the 50-star threshold)
- ✅ **crates.io**: Published as [`hexyl`](https://crates.io/crates/hexyl)
- ✅ **Author**: `sharkdp` — already has 3 entries in this list (`bat`, `fd`, `hyperfine`)