### PR TITLE
Add memvid to tooling section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1122,6 +1122,7 @@ See also [About Rust’s Machine Learning Community](https://medium.com/@autumn_
 
 * [BAML](https://github.com/BoundaryML/baml) - A simple prompting language for building reliable AI workflows and agents. BAML's compiler is written in Rust!
 * [Cortex Memory](https://github.com/sopaco/cortex-mem) - A complete solution for agent memory, from extraction and vector search to automated optimization, and insights dashboard out-of-the-box.
+* [memvid/memvid](https://github.com/memvid/memvid) [[memvid-core](https://crates.io/crates/memvid-core)] - A single-file portable memory layer for AI agents with vector search, full-text search, and long-term recall packed into one `.mv2` file
 
 ### Astronomy
 


### PR DESCRIPTION
## Summary

Adds [memvid](https://github.com/memvid/memvid) to the
**Libraries → Artificial Intelligence → Tooling** section.

## What is it?

Memvid is a portable, serverless memory layer for AI agents. It packages
embeddings, vector search (HNSW), full-text search (Tantivy/BM25), and
metadata into a single `.mv2` file — no external database required.
Supports local ONNX embeddings, OpenAI API embeddings, audio transcription
(Whisper), and CLIP visual search as optional feature flags.

## Why it qualifies

- ✅ **Stars**: 13,000+ GitHub stars (above the 50-star threshold)
- ✅ **crates.io**: Published as [`memvid-core`](https://crates.io/crates/memvid-core)