### PR TITLE
Add arimxyer/models

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ If you want to contribute, please read [this](CONTRIBUTING.md).
 * [ad-si/Woxi](https://github.com/ad-si/Woxi) [[woxi](https://crates.io/crates/woxi)] - An interpreter for the Wolfram Language powered by Rust.
 * [alacritty](https://github.com/alacritty/alacritty) - A cross-platform, GPU enhanced terminal emulator
 * [Andromeda](https://github.com/tryandromeda/andromeda) - JavaScript & TypeScript runtime built from the ground up in Rust 🦀 and powered by The Nova Engine.
+* [arimxyer/models](https://github.com/arimxyer/models) [[modelsdev](https://crates.io/crates/modelsdev)] - A TUI for browsing AI models, benchmarks, and coding agents [![CI](https://github.com/arimxyer/models/actions/workflows/ci.yml/badge.svg)](https://github.com/arimxyer/models/actions/workflows/ci.yml)
 * [Arti](https://gitlab.torproject.org/tpo/core/arti) - An implementation of Tor. (So far, it's a not-very-complete client. But watch this space!) [![Crates.io](https://img.shields.io/crates/v/arti.svg)](https://crates.io/crates/arti)
 * [asm-cli-rust](https://github.com/cch123/asm-cli-rust) - An interactive assembly shell.
 * [clash-verge-rev/clash-verge-rev](https://github.com/clash-verge-rev/clash-verge-rev) - A cross-platform, modern Clash GUI based on tauri & rust, supporting Windows, macOS, and Linux.


### PR DESCRIPTION
Added [arimxyer/models](https://github.com/arimxyer/models) to the Applications section.

- **Crate**: [modelsdev](https://crates.io/crates/modelsdev)
- **Description**: A TUI for browsing AI models, benchmarks, and coding agents
- **Stars**: 254+
- **CI badge**: Included (GitHub Actions)
- **Alphabetical ordering**: Placed between Andromeda and Arti
- **Format**: Follows the `[ACCOUNT/REPO](URL) [[CRATE](crates.io)] - DESCRIPTION` template from CONTRIBUTING.md