### PR TITLE
Add ki-editor to the list of text editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -645,6 +645,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 * [helix](https://github.com/helix-editor/helix) - A post-modern modal text editor inspired by Neovim/Kakoune. [![build badge](https://github.com/helix-editor/helix/actions/workflows/build.yml/badge.svg)](https://github.com/helix-editor/helix/actions)
 * [ilai-deutel/kibi](https://github.com/ilai-deutel/kibi) - A tiny (≤1024 LOC) text editor with syntax highlighting, incremental search and more. [![build badge](https://github.com/ilai-deutel/kibi/actions/workflows/ci.yml/badge.svg)](https://github.com/ilai-deutel/kibi/actions?query=branch%3Amaster)
 * [Inkwell](https://github.com/4worlds4w-svg/inkwell) - A portable, offline-first Markdown editor built with Tauri v2. Single executable, zero telemetry.
+* [ki-editor/ki-editor](https://github.com/ki-editor/ki-editor) - A multi-cursor combinatoric modal editor
 * [Lapce](https://github.com/lapce/lapce) - A modern editor with a backend. Taking inspiration from the discontinued [xi-editor](https://github.com/xi-editor/xi-editor).
 * [mathall/rim](https://github.com/mathall/rim) - Vim-like text editor.
 * [ox](https://github.com/curlpipe/ox) - An independent Rust text editor that runs in your terminal!


### PR DESCRIPTION
## Summary

Adds [ki-editor](https://github.com/ki-editor/ki-editor) to the
**Text editors** section.

## What is it?

Ki Editor is a multi-cursor combinatoric modal editor written in Rust.
It takes a unique approach to modal editing through composable,
combinatoric keybindings, with full documentation at ki-editor.org.

## Why it qualifies

- ✅ **Stars**: 700+ GitHub stars (well above the 50-star threshold)