### PR TITLE
Add Wilfred/difftastic to Development tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -804,6 +804,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 * [scriptisto](https://github.com/igor-petruk/scriptisto) - A language-agnostic "shebang interpreter" that enables you to write one file scripts in compiled languages. [![Build Status](https://cloud.drone.io/api/badges/igor-petruk/scriptisto/status.svg)](https://cloud.drone.io/igor-petruk/scriptisto)
 * [typos](https://github.com/crate-ci/typos) [[typos-cli](https://crates.io/crates/typos-cli)] - Source code spell checker
 * [VT Code](https://crates.io/crates/vtcode) - Terminal coding agent that pairs a modern TUI with deep, semantic code understanding powered by tree-sitter and ast-grep.
+* [Wilfred/difftastic](https://github.com/Wilfred/difftastic) [[difftastic](https://crates.io/crates/difftastic)] - A structural diff tool that understands syntax, supporting 30+ programming languages
 
 ### Build system
 


### PR DESCRIPTION
## Summary

Adds [difftastic](https://github.com/Wilfred/difftastic) to the
**Development tools** section.

## What is it?

Difftastic is a structural diff tool written in Rust that compares files
based on their syntax (via tree-sitter) rather than line-by-line.
It understands 30+ programming languages, integrates with git/mercurial,
and highlights exactly which pieces of syntax changed — not just which lines.

## Why it qualifies

- ✅ **Stars**: 24,000+ GitHub stars (well above the 50-star threshold)
- ✅ **crates.io**: Published as [`difftastic`](https://crates.io/crates/difftastic)