### PR TITLE
Add Tirea AI agent framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -1124,6 +1124,7 @@ See also [About Rust’s Machine Learning Community](https://medium.com/@autumn_
 * [liquidos-ai/AutoAgents](https://github.com/liquidos-ai/AutoAgents) [[AutoAgents](https://crates.io/crates/autoagents)] - Multi Agent Framework for building AI agents with native edge support.
 * [openai/codex](https://github.com/openai/codex) - Codex CLI is a coding agent from OpenAI that runs locally.
 * [openai/harmony](https://github.com/openai/harmony) [[openai-harmony](https://crates.io/crates/openai-harmony/0.0.3)] - Renderer for the harmony response format to be used with gpt-oss.
+* [Tirea](https://github.com/tirea-ai/tirea) — AI agent framework with typed state, multi-protocol serving (AG-UI, AI SDK, A2A, MCP), and multi-agent orchestration [![crates.io](https://img.shields.io/crates/v/tirea.svg)](https://crates.io/crates/tirea)
 * [zurawiki/tiktoken-rs](https://github.com/zurawiki/tiktoken-rs) [[tiktoken-rs](https://crates.io/crates/tiktoken-rs)] - Library for tokenizing text with OpenAI models using tiktoken. [![CI](https://github.com/zurawiki/tiktoken-rs/actions/workflows/ci.yml/badge.svg)](https://github.com/zurawiki/tiktoken-rs/actions/workflows/ci.yml)
 
 #### Tooling


### PR DESCRIPTION
## Summary

Adds [Tirea](https://github.com/tirea-ai/tirea) to the **Artificial Intelligence > OpenAI** section.

Tirea is an AI agent framework written in Rust that provides:
- Typed state management with a proc-macro derive system
- Multi-protocol serving: AG-UI, AI SDK, A2A, and MCP
- Multi-agent orchestration with sub-agent support
- Published on crates.io as [`tirea`](https://crates.io/crates/tirea)

The entry follows the existing alphabetical order in the OpenAI subsection (between `openai/harmony` and `zurawiki/tiktoken-rs`).