### PR TITLE
Add Ordo — high-performance rule engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ If you want to contribute, please read [this](CONTRIBUTING.md).
   * [Payments](#payments)
   * [Productivity](#productivity)
   * [Routing protocols](#routing-protocols)
+  * [Rule engines](#rule-engines)
   * [Security tools](#security-tools)
   * [Social networks](#social-networks)
   * [System tools](#system-tools)
@@ -511,6 +512,10 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 
 * [Holo](https://github.com/holo-routing/holo) - Holo is a suite of routing protocols designed to support high-scale and automation-driven networks
 * [RustyBGP](https://github.com/osrg/rustybgp) - BGP
+
+### Rule engines
+
+* [Pama-Lee/Ordo](https://github.com/Pama-Lee/Ordo) [[ordo-core](https://crates.io/crates/ordo-core)] - High-performance rule engine with Cranelift JIT, visual flow editor, and database filter push-down (SQL/JSON/MongoDB). [![CI](https://github.com/Pama-Lee/Ordo/actions/workflows/ci.yml/badge.svg)](https://github.com/Pama-Lee/Ordo/actions)
 
 ### Security tools
 


### PR DESCRIPTION
## Description

Adds [Ordo](https://github.com/Pama-Lee/Ordo) to a new **Rule engines** section under Applications.

Ordo is a high-performance rule engine written in Rust:
- Sub-microsecond rule execution (1.63 µs interpreter, 50–80 ns with Cranelift JIT)
- Visual flow editor (drag-and-drop, WASM-powered playground)
- Database filter push-down: partial evaluation → SQL / JSON / MongoDB `$match`
- HTTP REST + gRPC server, single binary deployment
- [`ordo-core`](https://crates.io/crates/ordo-core) published on crates.io

## Why a new section?

There is no existing rule engine or business rules section. The closest section (Workflow Automation) covers a different concept. Rule engines are a distinct category of infrastructure tooling with their own use cases (fraud scoring, discount logic, access control, routing decisions).

Placed alphabetically between **Routing protocols** and **Security tools**.

## Checklist

- [x] Added link is working
- [x] Description is accurate and concise
- [x] Placed in alphabetical order within section
- [x] ToC entry added
- [x] crates.io crate available: https://crates.io/crates/ordo-core