### PR TITLE
Add Awal Terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ If you want to contribute, please read [this](CONTRIBUTING.md).
 * [arimxyer/models](https://github.com/arimxyer/models) [[modelsdev](https://crates.io/crates/modelsdev)] - A TUI for browsing AI models, benchmarks, and coding agents [![CI](https://github.com/arimxyer/models/actions/workflows/ci.yml/badge.svg)](https://github.com/arimxyer/models/actions/workflows/ci.yml)
 * [Arti](https://gitlab.torproject.org/tpo/core/arti) - An implementation of Tor. (So far, it's a not-very-complete client. But watch this space!) [![Crates.io](https://img.shields.io/crates/v/arti.svg)](https://crates.io/crates/arti)
 * [asm-cli-rust](https://github.com/cch123/asm-cli-rust) - An interactive assembly shell.
+* [AwalTerminal/Awal-terminal](https://github.com/AwalTerminal/Awal-terminal) - An LLM-native terminal emulator for macOS with a Rust core, Metal GPU rendering, and AI component auto-detection
 * [clash-verge-rev/clash-verge-rev](https://github.com/clash-verge-rev/clash-verge-rev) - A cross-platform, modern Clash GUI based on tauri & rust, supporting Windows, macOS, and Linux.
 * [cloudflare/boringtun](https://github.com/cloudflare/boringtun) - A Userspace WireGuard VPN Implementation [![build badge](https://img.shields.io/crates/v/boringtun.svg)](https://crates.io/crates/boringtun)
 * [defguard](https://github.com/defguard/defguard) - Enterprise Open Source SSO & WireGuard VPN with real 2FA/MFA


### PR DESCRIPTION
Add [Awal Terminal](https://github.com/AwalTerminal/Awal-terminal) to the terminal emulator applications section. Awal Terminal is a macOS terminal emulator with a Rust core for terminal emulation and rendering via Metal GPU, with AI component auto-detection and multi-provider profiles.