### PR TITLE
Add vite-plus to Development tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -806,6 +806,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 * [Rustup](https://github.com/rust-lang/rustup) - the Rust toolchain installer [![build badge](https://github.com/rust-lang/rustup/actions/workflows/ci.yaml/badge.svg)](https://github.com/rust-lang/rustup/actions)
 * [scriptisto](https://github.com/igor-petruk/scriptisto) - A language-agnostic "shebang interpreter" that enables you to write one file scripts in compiled languages. [![Build Status](https://cloud.drone.io/api/badges/igor-petruk/scriptisto/status.svg)](https://cloud.drone.io/igor-petruk/scriptisto)
 * [typos](https://github.com/crate-ci/typos) [[typos-cli](https://crates.io/crates/typos-cli)] - Source code spell checker
+* [voidzero-dev/vite-plus](https://github.com/voidzero-dev/vite-plus) - A unified web development toolchain combining Vite, Vitest, Oxlint, Rolldown, and more into a single Rust-powered CLI (`vp`)
 * [VT Code](https://crates.io/crates/vtcode) - Terminal coding agent that pairs a modern TUI with deep, semantic code understanding powered by tree-sitter and ast-grep.
 * [Wilfred/difftastic](https://github.com/Wilfred/difftastic) [[difftastic](https://crates.io/crates/difftastic)] - A structural diff tool that understands syntax, supporting 30+ programming languages
 


### PR DESCRIPTION
## Summary

Adds [vite-plus](https://github.com/voidzero-dev/vite-plus) to the
**Development tools** section.

## What is it?

Vite+ is a unified web development toolchain whose CLI (`vp`) is written
in Rust. It combines Vite, Vitest, Oxlint, Oxfmt, Rolldown, and tsdown
into one zero-config tool that manages runtime, package manager, dev server,
linting, formatting, testing, and building in a single binary.

## Why it qualifies

- ✅ **Stars**: 1,000+ GitHub stars (above the 50-star threshold)
- ✅ **Written in Rust**: The `vp` CLI binary is compiled from Rust
  (primary language of the repo per GitHub language stats)