### PR TITLE
Add topjohnwu/Magisk to Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ If you want to contribute, please read [this](CONTRIBUTING.md).
 * [SWC](https://github.com/swc-project/swc) - super-fast TypeScript / JavaScript compiler
 * [temps](https://github.com/gotempsh/temps) - A self-hosted PaaS that replaces Vercel, analytics, error tracking, and uptime monitoring with a single Rust binary
 * [tiny](https://github.com/osa1/tiny) - A terminal IRC client
+* [topjohnwu/Magisk](https://github.com/topjohnwu/Magisk) - A suite of open source tools for customizing Android, providing root access, boot image manipulation, and systemless modifications
 * [Typst](https://github.com/typst/typst) - A markup-based typesetting system [![crates.io](https://img.shields.io/crates/v/typst.svg)](https://crates.io/crates/typst)
 * [UpVPN](https://github.com/upvpn/upvpn-app) - WireGuard VPN client for macOS, Linux, and Windows built on Tauri.
 * [vortix](https://github.com/Harry-kp/vortix) - Terminal UI for WireGuard and OpenVPN with real-time telemetry, leak detection, and kill switch


### PR DESCRIPTION
## Summary

Adds [Magisk](https://github.com/topjohnwu/Magisk) to the **Applications** section.

## What is it?

Magisk is an open-source suite for customizing Android devices (Android 6.0+),
providing root access (MagiskSU), systemless module support, boot image
manipulation (MagiskBoot), and Zygisk for injecting code into Android processes.

## Why it qualifies

- ✅ **Stars**: 59,000+ GitHub stars (well above the 50-star threshold)
- ✅ **Rust as primary language**: 35%+ of the codebase is Rust (per GitHub
  language stats); 40%+ of native code rewritten in Rust as of v29.0 (May 2025)
- ✅ **Active Rust migration**: Steadily rewriting C++ to Rust since April 2022,
  with major subsystem rewrites ongoing