### PR TITLE
Add siteone-crawler to Applications/Web

### DIFF
--- a/README.md
+++ b/README.md
@@ -738,6 +738,9 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 * [agrinman/tunnelto](https://github.com/agrinman/tunnelto) [[tunnelto](https://crates.io/crates/tunnelto)] - Lets you expose your locally running web server via a public URL.
 * [cfal/tobaru](https://github.com/cfal/tobaru) - Port forwarder with allowlists, IP and TLS SNI/ALPN rule-based routing, iptables support, round-robin forwarding (load balancing), and hot reloading.
 * [importantimport/hatsu](https://github.com/importantimport/hatsu) - 🩵 Self-hosted and fully-automated ActivityPub bridge for static sites. [![release](https://github.com/importantimport/hatsu/actions/workflows/release.yml/badge.svg)](https://github.com/importantimport/hatsu/actions/workflows/release.yml)
+* [janreges/siteone-crawler](https://github.com/janreges/siteone-crawler) [[siteone-crawler](https://crates.io/crates/siteone-crawler)] - All-in-one
+   website crawler, auditor, offline archiver, and AI-ready markdown exporter with CI/CD quality gating
+  [![CI](https://github.com/janreges/siteone-crawler/workflows/CI/badge.svg)](https://github.com/janreges/siteone-crawler/actions)
 * [LemmyNet/lemmy](https://github.com/LemmyNet/lemmy) - A link aggregator / reddit clone for the fediverse [![Build Status](https://cloud.drone.io/api/badges/LemmyNet/lemmy/status.svg)](https://cloud.drone.io/LemmyNet/lemmy)
 * [MASQ-Project/Node](https://github.com/MASQ-Project/Node) - MASQ Node software provides a decentralized mesh-network of nodes for global users to access normal internet content - next evolution of tech beyond Tor & VPN [![build badge](https://github.com/MASQ-Project/Node/actions/workflows/ci-matrix.yml/badge.svg)](https://github.com/MASQ-Project/Node/actions)
 * [Plume-org/Plume](https://github.com/Plume-org/Plume) - ActivityPub federating blogging application


### PR DESCRIPTION
## Add siteone-crawler

[siteone-crawler](https://github.com/janreges/siteone-crawler) is an all-in-one website crawler, auditor, offline archiver, and AI-ready markdown exporter with CI/CD quality gating.

- **GitHub stars:** 690+
- **License:** MIT
- **Crate:** [siteone-crawler](https://crates.io/crates/siteone-crawler)
- **Platforms:** Linux, macOS, Windows (x64 & arm64) — single native binary, zero dependencies
- **Category:** Applications > Web

### Key features
- Crawls entire websites and audits SEO, security, performance, accessibility, and best practices
- Quality scoring (0.0–10.0) across 5 weighted categories
- Offline website cloning with rewritten relative URLs
- Gallery of all images on the web
- Full-site markdown export (ideal for AI/LLM ingestion)
- Sitemap generation (XML/TXT)
- CI/CD quality gate (`--ci`) with configurable thresholds
- HTML audit reports with built-in SMTP mailer
- 120+ CLI options, config file support