### PR TITLE
Add glzr-io/glazewm to Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ If you want to contribute, please read [this](CONTRIBUTING.md).
 * [fcsonline/drill](https://github.com/fcsonline/drill) - A HTTP load testing application inspired by Ansible syntax
 * [fend](https://github.com/printfn/fend) - Arbitrary-precision unit-aware calculator [![build](https://github.com/printfn/fend/workflows/build/badge.svg)](https://github.com/printfn/fend/actions/workflows/actions.yml)
 * [Fractalide](https://github.com/fractalide/fractalide) - Simple microservices
+* [glzr-io/glazewm](https://github.com/glzr-io/glazewm) - A tiling window manager for Windows inspired by i3wm, with YAML config, multi-monitor support, and keyboard-driven commands
 * [google/mdbook-i18n-helpers](https://github.com/google/mdbook-i18n-helpers) [[mdbook-i18n-helpers](https://crates.io/crates/mdbook-i18n-helpers)] - Internationalization and rendering extensions for mdbook.
 * [habitat](https://github.com/habitat-sh/habitat) - A tool created by Chef to build, deploy, and manage applications.
 * [Herd](https://github.com/imjacobclark/Herd) - an experimental HTTP load testing application


### PR DESCRIPTION
## Summary

Adds [GlazeWM](https://github.com/glzr-io/glazewm) to the **Applications** section.

## What is it?

GlazeWM is a tiling window manager for Windows inspired by i3wm, fully
rewritten in Rust as of V3. It provides keyboard-driven window management,
YAML configuration, multi-monitor support, window rules, and integrates
with Zebar as a companion status bar.

## Why it qualifies

- ✅ **Stars**: 11,000+ GitHub stars (well above the 50-star threshold)
- ✅ **Written in Rust**: Complete Rust rewrite (V3), primary language
  per GitHub language stats; organized as a Rust workspace