### PR TITLE
Add SuperLightTUI to TUI libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1289,6 +1289,7 @@ See also [About Rust’s Machine Learning Community](https://medium.com/@autumn_
   * [ratatui-org/ratatui](https://github.com/ratatui/ratatui) [[ratatui](https://crates.io/crates/ratatui)] - Library that's all about cooking up terminal user interfaces (TUIs)
   * [redox-os/termion](https://github.com/redox-os/termion) [[termion](https://crates.io/crates/termion)] - bindless library for controlling terminals/TTY
   * [ruterm](https://crates.io/crates/ruterm) - tiny & simple library for working with TTY
+  * [subinium/SuperLightTUI](https://github.com/subinium/SuperLightTUI) [[superlighttui](https://crates.io/crates/superlighttui)] - Immediate-mode TUI library with 50+ widgets, flexbox layout, and animation system [![CI](https://github.com/subinium/SuperLightTUI/actions/workflows/ci.yml/badge.svg)](https://github.com/subinium/SuperLightTUI/actions/workflows/ci.yml)
   * Termbox
     * [gchp/rustbox](https://github.com/gchp/rustbox) [[rustbox](https://crates.io/crates/rustbox)] - bindings to [Termbox](https://github.com/nsf/termbox)
   * [TimonPost/crossterm](https://github.com/crossterm-rs/crossterm) [[crossterm](https://crates.io/crates/crossterm)] - crossplatform terminal library


### PR DESCRIPTION
Add [SuperLightTUI](https://github.com/subinium/SuperLightTUI) to the TUI libraries section.

Resubmission of #2289 — the project now meets the **50+ GitHub stars** criterion (currently 61⭐).

- GitHub: [subinium/SuperLightTUI](https://github.com/subinium/SuperLightTUI)
- crates.io: [superlighttui](https://crates.io/crates/superlighttui)
- docs.rs: [superlighttui](https://docs.rs/superlighttui)