### PR TITLE
Add bore TCP tunnel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1077,6 +1077,7 @@ See also [Are we (I)DE yet?](https://areweideyet.com/) and [Rust Tools](https://
 
 ### Tunnel
 
+* [ekzhang/bore](https://github.com/ekzhang/bore) [[bore-cli](https://crates.io/crates/bore-cli)] - A simple TCP tunnel to expose local ports to a remote server, bypassing NAT firewalls [![Build status](https://img.shields.io/github/actions/workflow/status/ekzhang/bore/ci.yml)](https://github.com/ekzhang/bore/actions)
 * [ngrok/ngrok-rust](https://github.com/ngrok/ngrok-rust) [[ngrok-rust](https://crates.io/crates/ngrok)] - ngrok is a developer tool that exposes your local app to the internet securely.
 * [rathole-org/rathole](https://github.com/rathole-org/rathole) - A secure, high-performance reverse proxy for NAT traversal with Noise Protocol/TLS encryption and hot-reload config support ![CI](https://img.shields.io/github/actions/workflow/status/rathole-org/rathole/rust.yml?branch=main)
 


### PR DESCRIPTION
Adds [bore](https://github.com/ekzhang/bore) to the
**Development tools → Tunnel** section.

## What is it?

`bore` is a minimal TCP tunnel written in Rust (~400 lines) that exposes
local ports to a remote server, bypassing NAT firewalls. It is similar to
ngrok and localtunnel but focused purely on TCP forwarding — no frills,
easy to self-host, with optional HMAC-based secret authentication.

## Why it qualifies

- ✅ **Stars**: 10,000+ GitHub stars (well above the 50-star threshold)
- ✅ **crates.io**: Published as [`bore-cli`](https://crates.io/crates/bore-cli)