### PR TITLE
Add webclaw — web extraction toolkit for LLMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -744,6 +744,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
   [![CI](https://github.com/janreges/siteone-crawler/workflows/CI/badge.svg)](https://github.com/janreges/siteone-crawler/actions)
 * [LemmyNet/lemmy](https://github.com/LemmyNet/lemmy) - A link aggregator / reddit clone for the fediverse [![Build Status](https://cloud.drone.io/api/badges/LemmyNet/lemmy/status.svg)](https://cloud.drone.io/LemmyNet/lemmy)
 * [MASQ-Project/Node](https://github.com/MASQ-Project/Node) - MASQ Node software provides a decentralized mesh-network of nodes for global users to access normal internet content - next evolution of tech beyond Tor & VPN [![build badge](https://github.com/MASQ-Project/Node/actions/workflows/ci-matrix.yml/badge.svg)](https://github.com/MASQ-Project/Node/actions)
+* [0xMassi/webclaw](https://github.com/0xMassi/webclaw) - Web content extraction toolkit for LLMs. CLI + MCP server with TLS fingerprinting, 10 extraction tools, and token-optimized output. Zero unsafe blocks.
 * [Plume-org/Plume](https://github.com/Plume-org/Plume) - ActivityPub federating blogging application
 * [Redlib](https://github.com/redlib-org/redlib) - An alternative private front-end to Reddit, with its origins in [Libreddit](https://github.com/libreddit/libreddit)
 * [shouya/rss-funnel](https://github.com/shouya/rss-funnel) - A modular RSS processing pipeline system.


### PR DESCRIPTION
Adds [webclaw](https://github.com/0xMassi/webclaw) to the Web section.

Web content extraction toolkit: CLI + MCP server for AI agents. 6 Rust crates, zero unsafe blocks, MIT licensed.

- TLS fingerprinting bypasses anti-bot without headless browser
- Pure extraction engine (webclaw-core) has zero network deps, WASM-compatible
- 10 MCP tools for Claude, Cursor, Windsurf, Codex, OpenCode
- 67% fewer tokens than raw HTML in LLM-optimized format
- CI: clippy -D warnings, cargo fmt enforced