### PR TITLE
Add Puffy to Video section

### DIFF
--- a/README.md
+++ b/README.md
@@ -723,6 +723,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 
 * [dertuxmalwieder/yaydl](https://github.com/dertuxmalwieder/yaydl) [[yaydl](https://crates.io/crates/yaydl)] - A simple video downloader
 * [gyroflow/gyroflow](https://github.com/gyroflow/gyroflow) - Video stabilization application using gyroscope data
+* [susu-pro/puffy](https://github.com/susu-pro/puffy) - Local-first media extraction and transcription engine for AI agents. Supports 8+ platforms, built-in Whisper, REST API on localhost. Built with Tauri 2.
 * [harlanc/xiu](https://github.com/harlanc/xiu) - A powerful and secure live server (rtmp/httpflv/hls/relay). [![crates.io](https://img.shields.io/crates/v/xiu.svg)](https://crates.io/crates/xiu)
 * [vidmerger](https://github.com/TGotwig/vidmerger) - Merge video & audio files via CLI
 * [xiph/rav1e](https://github.com/xiph/rav1e) - The fastest and safest AV1 encoder.


### PR DESCRIPTION
Adding [Puffy](https://github.com/susu-pro/puffy) — a local-first media extraction and transcription engine built entirely in Rust.

**What it does:** Paste any URL from 8+ platforms → get video + transcript + subtitles on your machine. Ships with on-device Whisper for speech-to-text, exposes a REST API on localhost via Axum.

- **Stack:** Rust + Tauri 2 + Axum + SQLite
- **Binary size:** ~56 MB
- **License:** MIT
- **GitHub:** https://github.com/susu-pro/puffy