### PR TITLE
Add Cortex to Artificial Intelligence > Tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1141,6 +1141,7 @@ See also [About Rust’s Machine Learning Community](https://medium.com/@autumn_
 #### Tooling
 
 * [BAML](https://github.com/BoundaryML/baml) - A simple prompting language for building reliable AI workflows and agents. BAML's compiler is written in Rust!
+* [Cortex](https://github.com/gambletan/cortex) - Local-first AI memory engine for AI agents — 4-tier memory, Bayesian beliefs, encrypted sync. 3.8MB binary, 62µs ingest.
 * [Cortex Memory](https://github.com/sopaco/cortex-mem) - A complete solution for agent memory, from extraction and vector search to automated optimization, and insights dashboard out-of-the-box.
 * [memvid/memvid](https://github.com/memvid/memvid) [[memvid-core](https://crates.io/crates/memvid-core)] - A single-file portable memory layer for AI agents with vector search, full-text search, and long-term recall packed into one `.mv2` file
 * [pydantic/monty](https://github.com/pydantic/monty) - A minimal, secure Python interpreter for running LLM-generated code in AI agents, with microsecond startup, strict sandboxing, and snapshotting support [![CI](https://github.com/pydantic/monty/actions/workflows/ci.yml/badge.svg)](https://github.com/pydantic/monty/actions/workflows/ci.yml)


### PR DESCRIPTION
## Summary

Adds [Cortex](https://github.com/gambletan/cortex) to the **Artificial Intelligence > Tooling** section.

**Entry:**
```
* [Cortex](https://github.com/gambletan/cortex) - Local-first AI memory engine for AI agents — 4-tier memory, Bayesian beliefs, encrypted sync. 3.8MB binary, 62µs ingest.
```

- Placed alphabetically between BAML and Cortex Memory
- Fits the Tooling subsection: infrastructure/tooling for building AI agents, not an ML framework or model binding
- Written in Rust; binary is 3.8MB, ingest latency 62µs

🤖 Generated with [Claude Code](https://claude.com/claude-code)