### PR TITLE
Add Plasmate - browser engine for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -744,7 +744,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
   [![CI](https://github.com/janreges/siteone-crawler/workflows/CI/badge.svg)](https://github.com/janreges/siteone-crawler/actions)
 * [LemmyNet/lemmy](https://github.com/LemmyNet/lemmy) - A link aggregator / reddit clone for the fediverse [![Build Status](https://cloud.drone.io/api/badges/LemmyNet/lemmy/status.svg)](https://cloud.drone.io/LemmyNet/lemmy)
 * [MASQ-Project/Node](https://github.com/MASQ-Project/Node) - MASQ Node software provides a decentralized mesh-network of nodes for global users to access normal internet content - next evolution of tech beyond Tor & VPN [![build badge](https://github.com/MASQ-Project/Node/actions/workflows/ci-matrix.yml/badge.svg)](https://github.com/MASQ-Project/Node/actions)
-* [plasmate-labs/plasmate](https://github.com/plasmate-labs/plasmate) - Browser engine for AI agents. Compiles HTML into Semantic Object Model (SOM). Built with html5ever + V8.
+* [plasmate-labs/plasmate](https://github.com/plasmate-labs/plasmate) [[plasmate](https://crates.io/crates/plasmate)] - Browser engine for AI agents. Compiles HTML into Semantic Object Model (SOM). Built with html5ever + V8.
 * [Plume-org/Plume](https://github.com/Plume-org/Plume) - ActivityPub federating blogging application
 * [Redlib](https://github.com/redlib-org/redlib) - An alternative private front-end to Reddit, with its origins in [Libreddit](https://github.com/libreddit/libreddit)
 * [shouya/rss-funnel](https://github.com/shouya/rss-funnel) - A modular RSS processing pipeline system.


### PR DESCRIPTION
[Plasmate](https://plasmate.app) is an open-source browser engine (Apache 2.0) that compiles HTML into a Semantic Object Model (SOM) for AI agents.

Added to **Applications > Web** in alphabetical order, following the list template and including the crates.io link.

GitHub: https://github.com/plasmate-labs/plasmate
crates.io: https://crates.io/crates/plasmate