### PR TITLE
Add crw to Web section

### DIFF
--- a/README.md
+++ b/README.md
@@ -738,6 +738,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 
 * [agrinman/tunnelto](https://github.com/agrinman/tunnelto) [[tunnelto](https://crates.io/crates/tunnelto)] - Lets you expose your locally running web server via a public URL.
 * [cfal/tobaru](https://github.com/cfal/tobaru) - Port forwarder with allowlists, IP and TLS SNI/ALPN rule-based routing, iptables support, round-robin forwarding (load balancing), and hot reloading.
+* [us/crw](https://github.com/us/crw) - Open-source web scraper and crawler built for AI agents. Single binary, built-in MCP server, Firecrawl-compatible API.
 * [importantimport/hatsu](https://github.com/importantimport/hatsu) - 🩵 Self-hosted and fully-automated ActivityPub bridge for static sites. [![release](https://github.com/importantimport/hatsu/actions/workflows/release.yml/badge.svg)](https://github.com/importantimport/hatsu/actions/workflows/release.yml)
 * [janreges/siteone-crawler](https://github.com/janreges/siteone-crawler) [[siteone-crawler](https://crates.io/crates/siteone-crawler)] - All-in-one
    website crawler, auditor, offline archiver, and AI-ready markdown exporter with CI/CD quality gating


### PR DESCRIPTION
Add [crw](https://github.com/us/crw) — an open-source web scraper and crawler built for AI agents. Single binary, built-in MCP server, Firecrawl-compatible API.