### PR TITLE
Add komodo to Development tools > Deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -879,6 +879,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
   * [kpcyrd/mini-docker-rust](https://github.com/kpcyrd/mini-docker-rust) - An example project for very small rust docker images
   * [liuchong/docker-rustup](https://github.com/liuchong/docker-rustup) - A multiple version (with musl tools) Rust Docker image
   * [LukeMathWalker/cargo-chef](https://github.com/LukeMathWalker/cargo-chef) - A tool and pre-built images for caching compiling remote dependencies between Docker builds.
+  * [moghtech/komodo](https://github.com/moghtech/komodo) - A tool to build and deploy software across many servers, with a web UI, API, and no server limits
   * [rust-cross/rust-musl-cross](https://github.com/rust-cross/rust-musl-cross) - Docker images for compiling static Rust binaries using musl-cross [![Build](https://github.com/rust-cross/rust-musl-cross/workflows/Build/badge.svg)](https://github.com/rust-cross/rust-musl-cross/actions?query=workflow%3ABuild)
   * [rust-lang-nursery/docker-rust](https://github.com/rust-lang/docker-rust) - the official Rust Docker image
   * [Stavrospanakakis/is_ready](https://github.com/Stavrospanakakis/is_ready) - Wait for multiple services to become available ![Build](https://github.com/Stavrospanakakis/is_ready/actions/workflows/release.yml/badge.svg)


### PR DESCRIPTION
## Summary

Adds [komodo](https://github.com/moghtech/komodo) to the
**Development tools → Deployment** section.

## What is it?

Komodo is an open-source tool written in Rust for building and deploying
software across multiple servers. It provides a web UI, REST API, and
unlimited server connections with no "business edition" restrictions.
Features include Docker stack management, environment sync, and server
stats monitoring.

## Why it qualifies

- ✅ **Stars**: 10,000+ GitHub stars (above the 50-star threshold)