### PR TITLE
Add webclaw — web content extraction for LLMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -739,6 +739,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 
 ### Web
 
+* [0xMassi/webclaw](https://github.com/0xMassi/webclaw) - Web content extraction for LLMs with TLS fingerprinting, MCP server, and no browser needed [![CI](https://github.com/0xMassi/webclaw/actions/workflows/ci.yml/badge.svg)](https://github.com/0xMassi/webclaw/actions)
 * [agrinman/tunnelto](https://github.com/agrinman/tunnelto) [[tunnelto](https://crates.io/crates/tunnelto)] - Lets you expose your locally running web server via a public URL.
 * [cfal/tobaru](https://github.com/cfal/tobaru) - Port forwarder with allowlists, IP and TLS SNI/ALPN rule-based routing, iptables support, round-robin forwarding (load balancing), and hot reloading.
 * [importantimport/hatsu](https://github.com/importantimport/hatsu) - 🩵 Self-hosted and fully-automated ActivityPub bridge for static sites. [![release](https://github.com/importantimport/hatsu/actions/workflows/release.yml/badge.svg)](https://github.com/importantimport/hatsu/actions/workflows/release.yml)


### PR DESCRIPTION
Adds [webclaw](https://github.com/0xMassi/webclaw) to the **Web** section.

Web content extraction toolkit for LLMs: CLI + MCP server. 6 Rust crates, zero unsafe blocks, MIT licensed.

- TLS fingerprinting bypasses anti-bot without headless browser
- Pure extraction engine (webclaw-core) has zero network deps, WASM-compatible
- 10 MCP tools for Claude, Cursor, Windsurf, Codex, OpenCode
- LLM-optimized markdown output (67% fewer tokens than raw HTML)

**Re-submission of #2312** — project now has **121 stars** (was under 50 when originally submitted). Meets the 50-star threshold per CONTRIBUTING.md.