### PR TITLE
Add Locally Uncensored to Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ If you want to contribute, please read [this](CONTRIBUTING.md).
 * [kftray](https://github.com/hcavarsan/kftray) - A cross-platform system tray app for managing and sharing multiple kubectl port-forward configurations. [![Build Status](https://github.com/hcavarsan/kftray/workflows/Release/badge.svg)](https://github.com/hcavarsan/kftray/actions)
 * [kytan](https://github.com/changlan/kytan) - High Performance Peer-to-Peer VPN
 * [linkerd/linkerd2-proxy](https://github.com/linkerd/linkerd2-proxy) - Ultralight service mesh for Kubernetes.
+* [PurpleDoubleD/locally-uncensored](https://github.com/PurpleDoubleD/locally-uncensored) - Open-source desktop app for running uncensored AI models locally with chat, image generation, and video generation. Built with Tauri.
 * [lzanini/mdbook-katex](https://github.com/lzanini/mdbook-katex) [[mdbook-katex](https://crates.io/crates/mdbook-katex)] - A preprocessor for [mdBook](https://github.com/rust-lang/mdBook), using KaTeX to render LaTeX math expressions.
 * [MaidSafe](https://github.com/maidsafe) - A decentralized platform.
 * [mayocream/koharu](https://github.com/mayocream/koharu) - An ML-powered manga translator with automatic speech bubble detection, OCR, inpainting, and LLM translation, built with Candle and Tauri


### PR DESCRIPTION
Adding [PurpleDoubleD/locally-uncensored](https://github.com/PurpleDoubleD/locally-uncensored) to the Applications section.

Locally Uncensored is an open-source desktop application for running uncensored AI models locally. It supports chat, image generation, and video generation — all fully private and offline. Built with Tauri (Rust backend), React, TypeScript, Ollama, and ComfyUI.

The entry is placed in alphabetical order in the Applications section and follows the existing entry format.