### PR TITLE
Add Entroly to AI Tooling section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2097,7 +2097,7 @@ See also [Are we game yet?](https://arewegameyet.rs)
 
 ### Text search
 
-* [andylokandy/simsearch-rs](https://github.com/andylokandy/simsearch-rs) [[simsearch](https://crates.io/crates/simsearch)] - A simple and lightweight fuzzy search engine that works in memory, searching for similar strings
+* [andylokandy/simsearch](https://github.com/andylokandy/simsearch) [[simsearch](https://crates.io/crates/simsearch)] - A simple and lightweight fuzzy search engine that works in memory, searching for similar strings
 * [BurntSushi/fst](https://github.com/BurntSushi/fst) [[fst](https://crates.io/crates/fst)] - a fast implementation of ordered sets and maps using finite state machines
 * [CurrySoftware/perlin](https://github.com/CurrySoftware/perlin) [[perlin](https://crates.io/crates/perlin)] - A lazy, zero-allocation and data-agnostic Information Retrieval library
 * [meilisearch/MeiliSearch](https://github.com/meilisearch/MeiliSearch) - Ultra relevant, instant and typo-tolerant full-text search API. [![Build Status](https://github.com/meilisearch/MeiliSearch/workflows/Cargo%20test/badge.svg?branch=master)](https://github.com/meilisearch/MeiliSearch/actions)


### PR DESCRIPTION
Re-submitting this to fix the issue identified in #2315. 
Entroly is hosted on PyPI, not crates.io (it's a Python package with a Rust core via PyO3). Following the `awesome-rust` contribution guidelines, I have completely removed the `[[CRATE](...)]` section from the entry so that it no longer causes a 404 error.