### PR TITLE
Add treepp to Applications/Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -726,6 +726,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 * [vaultwarden](https://github.com/dani-garcia/vaultwarden#readme) [![Build](https://github.com/dani-garcia/vaultwarden/actions/workflows/build.yml/badge.svg)](https://github.com/dani-garcia/vaultwarden/actions/workflows/build.yml) - Alternative implementation of the Bitwarden server API written in Rust
 * [Vibe](https://github.com/thewh1teagle/vibe) - Transcribe audio or video in every language on every platform.
 * [warpdotdev/Warp](https://github.com/warpdotdev/Warp) - :heavy_dollar_sign: Warp is a blazingly-fast modern GPU-accelerated terminal built to make you and your team more productive.
+* [Water-Run/treepp](https://github.com/Water-Run/treepp) - A Rust-based native Windows `tree` replacement with diff-level input/output compatibility on successful runs, many more features including essential exclusions and `.gitignore` support, and several-times faster performance.
 * [wrestic](https://github.com/alvaro17f/wrestic) - A wrapper around restic.
 * [wthrr](https://github.com/ttytm/wthrr-the-weathercrab) - Weather companion for the terminal. [![crates.io](https://img.shields.io/crates/v/wthrr?logo=rust)](https://crates.io/crates/wthrr)
 


### PR DESCRIPTION
This PR adds `treepp` to the Applications/Utilities section.

**Project highlights:**
- Replaces the native Windows `tree` command with a faster, multi-threaded Rust implementation.
- Adds missing features such as `.gitignore` parsing, depth limitation, and exclusion rules.
- Maintains diff-level input/output compatibility with the original command.

**Contribution guidelines compliance:**
- [x] The repository has over 50 stars (currently 67 stars).
- [x] The entry is placed in strict alphabetical order (`Water-Run` follows `warpodotdev`).
- [x] Formatting strictly follows the `[ACCOUNT/REPO](URL) - DESCRIPTION` standard.