### PR TITLE
Add unifly to System tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,6 +598,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 * [gitui](https://github.com/gitui-org/gitui) - Blazing fast terminal client for git. [![build](https://github.com/gitui-org/gitui/actions/workflows/ci.yml/badge.svg)](https://github.com/gitui-org/gitui/actions)
 * [GQL](https://github.com/amrdeveloper/gql) - A SQL like query language to run on .git files.
 * [httm](https://github.com/kimono-koans/httm) - Interactive, file-level Time Machine-like tool for ZFS/btrfs/nilfs2 (and even actual Time Machine backups!)
+* [hyperb1iss/unifly](https://github.com/hyperb1iss/unifly) [[unifly](https://crates.io/crates/unifly)] - CLI and TUI for managing Ubiquiti UniFi network controllers with dual-API coverage and a 10-screen Ratatui dashboard [![CI](https://github.com/hyperb1iss/unifly/actions/workflows/cicd.yml/badge.svg)](https://github.com/hyperb1iss/unifly/actions/workflows/cicd.yml)
 * [j0ru/kickoff](https://github.com/j0ru/kickoff) - Fast and snappy wayland program launcher [![build](https://github.com/j0ru/kickoff/actions/workflows/ci.yml/badge.svg)](https://github.com/j0ru/kickoff/actions)
 * [jacek-kurlit/pik](https://github.com/jacek-kurlit/pik) [[pik](https://crates.io/crates/pik)] - A TUI command line tool that helps to find and kill processes
 * [Kondo](https://github.com/tbillington/kondo) - CLI & GUI tool for deleting software project artifacts and reclaiming disk space


### PR DESCRIPTION
unifly is a CLI and TUI for managing Ubiquiti UniFi network controllers, built with Rust and Ratatui.

It ships 26 top-level commands for scripting and a 10-screen interactive dashboard with live bandwidth charts, zoomable topology, and firewall policy management. The dual-API engine speaks both the modern Integration API and the Session API, reconciling data between them automatically.

Published on crates.io as both `unifly` (binary) and `unifly-api` (library for custom integrations). 120+ GitHub stars. Apache-2.0 licensed.

https://github.com/hyperb1iss/unifly