### PR TITLE
Add Kite — webhook relay for AI agents (Tunnel section)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1096,6 +1096,7 @@ See also [Are we (I)DE yet?](https://areweideyet.com/) and [Rust Tools](https://
 * [ekzhang/bore](https://github.com/ekzhang/bore) [[bore-cli](https://crates.io/crates/bore-cli)] - A simple TCP tunnel to expose local ports to a remote server, bypassing NAT firewalls [![Build status](https://img.shields.io/github/actions/workflow/status/ekzhang/bore/ci.yml)](https://github.com/ekzhang/bore/actions)
 * [ngrok/ngrok-rust](https://github.com/ngrok/ngrok-rust) [[ngrok-rust](https://crates.io/crates/ngrok)] - ngrok is a developer tool that exposes your local app to the internet securely.
 * [rathole-org/rathole](https://github.com/rathole-org/rathole) - A secure, high-performance reverse proxy for NAT traversal with Noise Protocol/TLS encryption and hot-reload config support ![CI](https://img.shields.io/github/actions/workflow/status/rathole-org/rathole/rust.yml?branch=main)
+* [lommaj/kite](https://github.com/lommaj/kite) - Webhook relay for AI agents with built-in signature verification (Stripe, GitHub, Slack), CloudEvents 1.0 standardization, and sub-10ms latency. Self-hostable Rust binary. [![Build status](https://img.shields.io/github/actions/workflow/status/lommaj/kite/ci.yml)](https://github.com/lommaj/kite/actions)
 
 ## Libraries
 


### PR DESCRIPTION
Hi! I'd like to add Kite to the Tunnel section of awesome-rust.

**What it is:** Kite is an open-source webhook relay built with Rust for AI agents and developers.

**Key features**:
- Built-in signature verification for major webhook sources (Stripe, GitHub, Slack)
- CloudEvents 1.0 standardization for interoperable event payloads
- Sub-10ms median latency (Rust + Tokio async)
- Agent-native streaming (pipe events directly to stdin)
- Self-hostable as a single binary or Docker container

**Why it fits in Tunnel**: Like bore and ngrok, Kite creates secure tunnels for webhook delivery. But unlike generic tunneling tools, Kite is purpose-built for webhooks with signature verification, retry logic, and CloudEvents normalization.

**Repo stats**:
- License: MIT/Apache-2.0
- Language: Rust
- Last commit: Active (within 7 days)
- CI: Passing GitHub Actions

**Links**:
- GitHub: https://github.com/lommaj/kite
- Website: https://getkite.sh
- Docs: https://getkite.sh/docs

Thanks for maintaining this list!