### PR TITLE
Add md-preview to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -702,6 +702,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 * [gitlogue](https://github.com/unhappychoice/gitlogue) - A TUI screensaver that visualizes Git commit history in your terminal
 * [guoxbin/dtool](https://github.com/guoxbin/dtool) - A useful command-line tool collection to assist development including conversion, codec, hashing, encryption, etc.
 * [Linus-Mussmaecher/rucola](https://github.com/Linus-Mussmaecher/rucola) - Terminal-based markdown note manager. [![Crate](https://img.shields.io/crates/v/rucola-notes.svg?logo=rust)](https://crates.io/crates/rucola-notes) [![Build Status](https://github.com/Linus-Mussmaecher/rucola/actions/workflows/continuous-testing.yml/badge.svg)](https://github.com/Linus-Mussmaecher/rucola/actions/workflows/continuous-testing.yml)
+* [md-preview](https://github.com/vorojar/md-preview) - Ultra-lightweight Markdown preview app (~1MB binary) built with Rust + wry, featuring offline syntax highlighting and cross-platform support.
 * [Mobslide](https://github.com/thewh1teagle/mobslide) - Desktop application that turns your smartphone into presentation remote controller.
 * [mprocs](https://github.com/pvolok/mprocs) - TUI for running multiple processes
 * [mrjackwills/oxker](https://github.com/mrjackwills/oxker) [[oxker](https://crates.io/crates/oxker)] - A simple tui to view & control docker containers.


### PR DESCRIPTION
## Summary

- Add [md-preview](https://github.com/vorojar/md-preview) to the **Utilities** section of README.md
- md-preview is an ultra-lightweight Markdown preview app (~1MB binary) built with Rust + wry, featuring offline syntax highlighting and cross-platform support

## Checklist

- [x] Entry follows the existing format (`* [name](url) - description`)
- [x] Placed in alphabetical order within the Utilities section
- [x] Project is written in Rust
- [x] Project has a working README with description