### PR TITLE
Add SwitchShuttle to applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ If you want to contribute, please read [this](CONTRIBUTING.md).
 * [Rust Iot Platform](https://github.com/iot-ecology/rust-iot-platform) - A high-performance IoT development platform built with Rust, designed for multi-protocol support and real-time data processing. This platform supports MQTT, WebSockets (WS), TCP, and CoAP protocols, making it highly flexible for diverse IoT applications.
 * [rx](https://github.com/cloudhead/rx) - Vi inspired Modern Pixel Art Editor
 * [Ryot](https://github.com/ignisda/ryot) - A self hosted application to track media consumption, fitness, etc.
+* [s00d/switchshuttle](https://github.com/s00d/switchshuttle) - Cross-platform system tray app for organizing and running predefined terminal commands with global hotkeys, nested menus, and JSON-backed configuration (Tauri + Vue).
 * [Saga Reader](https://github.com/sopaco/saga-reader) - A Blazing-Fast and Extremely-Lightweight Internet Reader driven by AI.Supports fetching of search engine information and RSS.
 * [Servo](https://github.com/servo/servo) - A prototype web browser engine
 * [shoes](https://github.com/cfal/shoes) - A multi-protocol proxy server


### PR DESCRIPTION
## Summary
Adds [SwitchShuttle](https://github.com/s00d/switchshuttle) to the **Applications** section of the list.

## Project
SwitchShuttle is a cross-platform desktop app (Rust + Tauri + Vue) that lives in the system tray: organize predefined terminal commands, global hotkeys, nested menus, JSON configuration with validation, optional scheduling, and a small CLI—similar spirit to the classic Shuttle workflow, rebuilt for modern stacks.

## CONTRIBUTING.md checklist
- **Popularity**: GitHub stars are above the minimum (**120** stars at submission time; threshold is **50**). The project is not published as a standalone library on crates.io, so the `[[CRATE](...)]` segment is omitted.
- **Format**: `[s00d/switchshuttle](https://github.com/s00d/switchshuttle) - …` as required.
- **Sort order**: Inserted in **alphabetical** order in the Applications list (after Ryot, before Saga Reader).
- **CI badge**: Not added—release builds are manual `workflow_dispatch` workflows only, so a workflow status badge would not reflect ongoing CI.

## Note on prior PR
This replaces the intent of [#1771](https://github.com/rust-unofficial/awesome-rust/pull/1771), which was closed because the repo had not yet reached the popularity bar at that time.

Made with [Cursor](https://cursor.com)