### PR TITLE
Add yantrikdb-server to Machine learning section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1152,6 +1152,7 @@ See also [About Rust’s Machine Learning Community](https://medium.com/@autumn_
 * [smartcorelib/smartcore](https://github.com/smartcorelib/smartcore) - Machine Learning Library [![Build Status](https://img.shields.io/circleci/build/github/smartcorelib/smartcore)]
 * [tag1consulting/feste](https://github.com/tag1consulting/feste) - A GPT-2 style transformer language model implemented from scratch in Rust for educational purposes.
 * [tensorflow/rust](https://github.com/tensorflow/rust) - Bindings for TensorFlow.
+* [yantrikos/yantrikdb-server](https://github.com/yantrikos/yantrikdb-server) [[yantrikdb-server](https://crates.io/crates/yantrikdb-server)] - Cognitive memory database for AI agents. Actively manages stored memories: consolidation, contradiction detection, temporal decay. Embeddable as a Rust/Python library or run as a clustered HTTP server with CRDT replication and parking_lot runtime deadlock detection.
 
 #### OpenAI
 


### PR DESCRIPTION
Adds YantrikDB to the Artificial Intelligence → Machine learning subsection.

**What it is:** A cognitive memory database for AI agents, written in Rust. Unlike vector databases (which store embeddings and do nearest-neighbor search), it actively manages stored memories via three first-class operations:

- **Consolidation** — `think()` collapses similar memories into canonical ones
- **Contradiction detection** — flags when stored facts conflict
- **Temporal decay** — configurable half-life makes unimportant memories fade

**Rust specifics:**
- Single binary, optional 2-voter + 1-witness HA cluster with CRDT replication
- Uses `parking_lot` with runtime deadlock detection (caught a production self-deadlock in seconds vs hours)
- `fastembed` + ONNX Runtime for built-in embeddings (all-MiniLM-L6-v2)
- SQLite (via rusqlite) + HNSW vector index, both behind parking_lot mutexes
- Tokio async + axum HTTP gateway + binary wire protocol (MessagePack + custom codec)

**Deployment:** Embeddable Rust crate, Python bindings, standalone network server (Docker/K8s manifests in deploy/), or MCP server for Claude Code/Cursor.

**Status:** Live on a 3-node homelab cluster with multiple tenants. Recently completed a 42-task hardening sprint — 1178 core tests, cargo-fuzz targets, CRDT convergence property tests, 5 ops runbooks. AGPL-3.0.

**Links:**
- Repo: https://github.com/yantrikos/yantrikdb-server
- Crates: https://crates.io/crates/yantrikdb-server
- Docs: https://yantrikdb.com

Happy to iterate on placement or phrasing if the section doesn't fit.