### PR TITLE
Add git-parsec: git worktree lifecycle manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -596,6 +596,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 * [fork](https://github.com/immortal/fork) - Library for creating a new process detached from the controlling terminal (daemon)
 * [fselect](https://crates.io/crates/fselect) - Find files with SQL-like queries
 * [git-ai-project/git-ai](https://github.com/git-ai-project/git-ai) - A git extension that tracks AI-generated code in your repositories, linking lines to the agent, model, and transcripts.
+* [git-parsec](https://github.com/erishforG/git-parsec) [[git-parsec](https://crates.io/crates/git-parsec)] - Git worktree lifecycle manager that ties worktrees to issue tickets (Jira, GitHub Issues, GitLab) for parallel development. [![build](https://github.com/erishforG/git-parsec/actions/workflows/ci.yml/badge.svg)](https://github.com/erishforG/git-parsec/actions)
 * [gitbutlerapp/gitbutler](https://github.com/gitbutlerapp/gitbutler) - A modern Git-based version control interface with both a GUI and CLI built from the ground up for AI-powered workflows.
 * [gitui](https://github.com/gitui-org/gitui) - Blazing fast terminal client for git. [![build](https://github.com/gitui-org/gitui/actions/workflows/ci.yml/badge.svg)](https://github.com/gitui-org/gitui/actions)
 * [GQL](https://github.com/amrdeveloper/gql) - A SQL like query language to run on .git files.


### PR DESCRIPTION
## What is git-parsec?

[git-parsec](https://github.com/erishforG/git-parsec) is a CLI tool that manages the full lifecycle of git worktrees tied to issue tracker tickets.

When working on multiple tickets in parallel — or running several AI coding agents on the same repository — each task needs its own isolated worktree to avoid `index.lock` conflicts. git-parsec automates the repetitive parts: creating worktrees from ticket IDs, fetching titles from Jira/GitHub Issues/GitLab, pushing + creating PRs, and cleaning up afterwards.

### Key points

- Written in Rust, published on [crates.io](https://crates.io/crates/git-parsec)
- Integrates with Jira, GitHub Issues, and GitLab for ticket lookup
- One command to ship: push, create PR, and clean up the worktree
- Cross-worktree conflict detection, CI monitoring, operation history with undo
- Machine-readable JSON output for scripting and automation
- MIT licensed

### Links

- Repository: https://github.com/erishforG/git-parsec
- Crate: https://crates.io/crates/git-parsec
- Docs: https://erishforg.github.io/git-parsec/