### PR TITLE
Add RustChain - DePIN blockchain for vintage hardware

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ If you want to contribute, please read [this](CONTRIBUTING.md).
 * [rust-lightning](https://github.com/lightningdevkit/rust-lightning) [![Crate](https://img.shields.io/crates/v/lightning.svg?logo=rust)](https://crates.io/crates/lightning) - Bitcoin Lightning library. The main crate,`lightning`, does not handle networking, persistence, or any other I/O. Thus,it is runtime-agnostic, but users must implement basic networking logic, chain interactions, and disk storage.po on linking crate.
 * [sigma-rust](https://github.com/ergoplatform/sigma-rust) - ErgoTree interpreter and wallet-related features.
 * [starkware-libs/cairo-vm](https://github.com/starkware-libs/cairo-vm) - Implementation of the Cairo VM [![rust](https://github.com/starkware-libs/cairo-vm/actions/workflows/rust.yml/badge.svg)](https://github.com/starkware-libs/cairo-vm/actions/workflows/rust.yml)
+* [RustChain](https://github.com/Scottcjn/Rustchain) - DePIN blockchain for vintage hardware with Proof-of-Antiquity mining.
 * [Subspace](https://github.com/autonomys/subspace) - The first layer-one blockchain that can fully resolve the blockchain trilemma by simultaneously achieving scalability, security, and decentralization.
 * [Sui](https://github.com/MystenLabs/sui) - A next-generation smart contract platform with high throughput, low latency, and an asset-oriented programming model powered by the Move programming language.
 * [svm-rs](https://github.com/alloy-rs/svm-rs) - Solidity-Compiler Version Manager.


### PR DESCRIPTION
## RustChain

Added RustChain to the Blockchain section.

### About
- **DePIN blockchain for vintage hardware** - Old machines outmine new ones
- **Proof-of-Antiquity mining** - Unique consensus based on hardware age
- **15+ CPU architectures supported**: PowerPC G4/G5, 486, and more
- **Solana bridge**: wRTC token on Solana network

### Links
- Repo: https://github.com/Scottcjn/Rustchain
- Website: https://rustchain.org

### Checklist
- [x] Entry follows the existing format
- [x] Description is concise
- [x] Link is valid
