### PR TITLE
Add branch-watch — GitHub branch & fork sync status CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,6 +619,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 * [mmstick/tv-renamer](https://github.com/mmstick/tv-renamer) - A tv series renaming application with an optional GTK3 frontend.
 * [mxseev/logram](https://github.com/mxseev/logram) - Push log files' updates to Telegram
 * [netscanner](https://github.com/Chleba/netscanner) - TUI Network Scanner
+* [nuri-yoo/branch-watch](https://github.com/nuri-yoo/branch-watch) [[branch-watch](https://crates.io/crates/branch-watch)] - CLI tool to track branch and fork sync status across GitHub repositories [![Release](https://img.shields.io/github/v/release/nuri-yoo/branch-watch)](https://github.com/nuri-yoo/branch-watch/releases)
 * [nickgerace/gfold](https://github.com/nickgerace/gfold) [[gfold](https://crates.io/crates/gfold)] - CLI tool to help keep track of multiple Git repositories [![build](https://img.shields.io/github/workflow/status/nickgerace/gfold/merge/main)](https://github.com/nickgerace/gfold/actions?query=workflow%3Amerge+branch%3Amain)
 * [nivekuil/rip](https://github.com/nivekuil/rip) - A safe and ergonomic alternative to `rm`
 * [nushell/nushell](https://github.com/nushell/nushell) - A new type of shell


### PR DESCRIPTION
## Description

Add [branch-watch](https://github.com/nuri-yoo/branch-watch) to the Development tools section.

`branch-watch` (`bw`) is a fast, single-binary CLI written in Rust that shows — at a glance — whether your GitHub branches are behind `main`, how far your forks have drifted from upstream, and what pull requests are open. No local clone required; queries the GitHub REST API directly.

**Key features:**
- `bw branches owner/repo` — shows every branch vs. default branch with behind/ahead counts
- `bw forks` — lists all your forked repos vs. upstream
- `bw prs owner/repo` — lists open PRs with age
- `--behind-only` filter, `--json` output, `gh` CLI token auto-detection
- Available via `cargo install branch-watch`, `pip install branch-watch`, `npm install -g branch-watch`, and Homebrew

**Links:** [crates.io](https://crates.io/crates/branch-watch) · [PyPI](https://pypi.org/project/branch-watch/) · [npm](https://www.npmjs.com/package/branch-watch)