### PR TITLE
Add Kaku terminal emulator to System tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -643,6 +643,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 * [supercilex/fuc](https://github.com/supercilex/fuc) - Fast `cp` and `rm` commands
 * [topheman/webassembly-component-model-experiments](https://github.com/topheman/webassembly-component-model-experiments) - WebAssembly Component Model based REPL with sandboxed multi-language plugin system [![Crates.io](https://img.shields.io/crates/v/pluginlab.svg)](https://crates.io/crates/pluginlab)
 * [trippy](https://github.com/fujiapple852/trippy) - A network diagnostic tool [![build badge](https://github.com/fujiapple852/trippy/workflows/CI/badge.svg)](https://github.com/fujiapple852/trippy/actions/workflows/ci.yml)
+* [tw93/Kaku](https://github.com/tw93/Kaku) - A fast, out-of-the-box terminal emulator built for AI coding, with zero-config defaults, AI assistant integration, and WezTerm-compatible Lua configuration. macOS-only.
 * [uutils/coreutils](https://github.com/uutils/coreutils) - A cross-platform rewrite of the GNU coreutils [![CICD](https://github.com/uutils/coreutils/actions/workflows/CICD.yml/badge.svg)](https://github.com/uutils/coreutils/actions/workflows/CICD.yml)
 * [watchexec](https://github.com/watchexec/watchexec) - Executes commands in response to file modifications
 * [XAMPPRocky/tokei](https://github.com/XAMPPRocky/tokei) - counts the lines of code


### PR DESCRIPTION
## Description
Add [Kaku](https://github.com/tw93/Kaku) to the Applications > System tools section.

## About
Kaku is a deeply customized fork of WezTerm, designed as a fast, out-of-the-box terminal for AI-assisted coding workflows:
-  Zero-config defaults with JetBrains Mono, optimized font rendering
-  Theme-aware: auto-switches between dark/light modes with tuned colors
-  Built-in AI assistant: error recovery suggestions & natural-language-to-command
-  WezTerm-compatible Lua config: full API compatibility, no migration needed
-  Lightweight: ~40% smaller binary, instant startup, lazy loading
-  macOS-only (notarized by Apple)

## Criteria Check
-  GitHub stars: >50 