### PR TITLE
add gloamy to productivity section

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,6 +505,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 * [fulsomenko/kanban](https://github.com/fulsomenko/kanban) [[kanban-tui](https://crates.io/crates/kanban-tui)] - Terminal-based project management tool inspired by lazygit [![CI](https://github.com/fulsomenko/kanban/actions/workflows/ci.yml/badge.svg)](https://github.com/fulsomenko/kanban/actions/workflows/ci.yml)
 * [Furtherance](https://github.com/unobserved-io/Furtherance) - Time tracking app built with GTK4
 * [graves/awful_aj](https://github.com/graves/awful_aj) [[awful_aj](https://crates.io/crates/awful_aj)] - A CLI for working with OpenAI-compatible APIs, YAML templates for prompt engineering and a built in Vector Database for persistent memories.
+* [iBz-04/gloamy](https://github.com/iBz-04/gloamy) [[gloamy](https://crates.io/crates/gloamy)] - Rust-first autonomous agent runtime for CLI, channels, gateway, and hardware workflows.
 * [illacloud/illa](https://github.com/illacloud/illa) - Low-code internal tool builder.
 * [iwe-org/iwe](https://github.com/iwe-org/iwe) [[iwe](https://crates.io/crates/iwe)] - A markdown-based knowledge management tool with LSP server and CLI [![Build Status](https://github.com/iwe-org/iwe/actions/workflows/rust.yml/badge.svg)](https://github.com/iwe-org/iwe/actions/workflows/rust.yml)
 * [kruseio/hygg](https://github.com/kruseio/hygg) [[hygg](https://crates.io/crates/hygg)] - 📚 Simplifying the way you read. Minimalistic Vim-like TUI document reader.


### PR DESCRIPTION
Add gloamy to Productivity section

gloamy is a Rust-first autonomous agent operating system connected to CLI, channels, web gateways, and comes with a desktop application.


**Popularity metric:** 51 GitHub stars (exceeds the 50-star threshold per contributing guidelines)

- GitHub: https://github.com/iBz-04/gloamy
- Crates.io: https://crates.io/crates/gloamy