### PR TITLE
Add RustChain - Proof-of-Antiquity blockchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ If you want to contribute, please read [this](CONTRIBUTING.md).
 * [Lighthouse](https://github.com/sigp/lighthouse) - Ethereum Consensus Layer (CL) Client [![Build Status](https://github.com/sigp/lighthouse/actions/workflows/test-suite.yml/badge.svg)](https://github.com/sigp/lighthouse/actions)
 * [linera-io/linera-protocol](https://github.com/linera-io/linera-protocol) - A decentralized blockchain infrastructure designed for highly scalable, low-latency Web3 applications [![Build Status](https://github.com/linera-io/linera-protocol/actions/workflows/rust.yml/badge.svg)](https://github.com/linera-io/linera-protocol/actions/workflows/rust.yml)
 * [near/nearcore](https://github.com/near/nearcore) - decentralized smart-contract platform for low-end mobile devices.
+* [RustChain](https://github.com/Scottcjn/Rustchain) - Proof-of-Antiquity blockchain rewarding vintage hardware with Python + Rust hybrid architecture.
 * [Nervos CKB](https://github.com/nervosnetwork/ckb) - Nervos CKB is a public permissionless blockchain, the common knowledge layer of Nervos network.
 * [opensea-rs](https://github.com/gakonst/opensea-rs) - Bindings & CLI to the Opensea API and Contracts.
 * [Parity-Bitcoin](https://github.com/paritytech/parity-bitcoin) - The Parity Bitcoin client


### PR DESCRIPTION
## RustChain — Proof-of-Antiquity Blockchain

Added to the **Blockchain** section in alphabetical order.

**Why RustChain:**

- **Proof-of-Antiquity (PoA)** — rewards authentic vintage hardware (DOS era, Amiga, classic Macs, N64, etc.)
- **Python + Rust hybrid** — Python for AI/ML agent discovery, Rust for consensus/signing
- **Hardware attestation** via Beacon's TPM-based fingerprinting
- **Antiquity multipliers** — older hardware earns higher rewards (up to 1000x for pre-1985 devices)
- 82 GitHub stars, active node network since 2026-01

**Website:** https://rustchain.org
**Repo:** https://github.com/Scottcjn/Rustchain