### PR TITLE
Add peeroxide — Pure Rust Hyperswarm P2P stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1954,6 +1954,7 @@ See also [Are we game yet?](https://arewegameyet.rs)
 * P2P
   * [libp2p/rust-libp2p](https://github.com/libp2p/rust-libp2p) - Implementation of libp2p networking stack. [![Circle CI](https://circleci.com/gh/libp2p/rust-libp2p.svg?style=svg)](https://app.circleci.com/pipelines/github/libp2p/rust-libp2p)
   * [n0-computer/iroh](https://github.com/n0-computer/iroh) [[iroh](https://crates.io/crates/iroh)] - crate for building on direct connections between devices [![CI](https://github.com/n0-computer/iroh/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/n0-computer/iroh/actions/workflows/ci.yml)
+  * [Rightbracket/peeroxide](https://github.com/Rightbracket/peeroxide) [[peeroxide](https://crates.io/crates/peeroxide)] - Pure Rust Hyperswarm P2P stack with Kademlia DHT, Noise encryption, UDP hole-punching, and BBR congestion control [![CI](https://github.com/Rightbracket/peeroxide/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/Rightbracket/peeroxide/actions/workflows/ci.yml)
 * POP3
   * [mattnenterprise/rust-pop3](https://github.com/mattnenterprise/rust-pop3) [[pop3](https://crates.io/crates/pop3)] - A [POP3](https://en.wikipedia.org/wiki/Post_Office_Protocol) client
 * QUIC


### PR DESCRIPTION
Adds [peeroxide](https://github.com/Rightbracket/peeroxide) to the P2P section under Networking.

peeroxide is a pure Rust implementation of the [Hyperswarm](https://github.com/holepunchto/hyperswarm) P2P networking stack, wire-compatible with the existing Node.js network. It includes:

- Kademlia DHT with hole-punching and blind relay
- Noise XX/IK encrypted connections (Ed25519, ChaCha20-Poly1305)
- Reliable UDP transport with BBR congestion control
- Topic-based peer discovery

Published on crates.io: [peeroxide](https://crates.io/crates/peeroxide), [peeroxide-dht](https://crates.io/crates/peeroxide-dht), [libudx](https://crates.io/crates/libudx)