### PR TITLE
Add RustChain - Proof-of-Antiquity blockchain for vintage hardware

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ If you want to contribute, please read [this](CONTRIBUTING.md).
 * [kftray](https://github.com/hcavarsan/kftray) - A cross-platform system tray app for managing and sharing multiple kubectl port-forward configurations. [![Build Status](https://github.com/hcavarsan/kftray/workflows/Release/badge.svg)](https://github.com/hcavarsan/kftray/actions)
 * [kytan](https://github.com/changlan/kytan) - High Performance Peer-to-Peer VPN
 * [linkerd/linkerd2-proxy](https://github.com/linkerd/linkerd2-proxy) - Ultralight service mesh for Kubernetes.
+* [LWE](https://github.com/YangYuS8/lwe) - Linux desktop app for browsing, managing, and applying Wallpaper Engine content, built with Rust and Tauri.
 * [lzanini/mdbook-katex](https://github.com/lzanini/mdbook-katex) [[mdbook-katex](https://crates.io/crates/mdbook-katex)] - A preprocessor for [mdBook](https://github.com/rust-lang/mdBook), using KaTeX to render LaTeX math expressions.
 * [MaidSafe](https://github.com/maidsafe) - A decentralized platform.
 * [mayocream/koharu](https://github.com/mayocream/koharu) - An ML-powered manga translator with automatic speech bubble detection, OCR, inpainting, and LLM translation, built with Candle and Tauri
@@ -250,7 +251,7 @@ If you want to contribute, please read [this](CONTRIBUTING.md).
 * [pragma-org/amaru](https://github.com/pragma-org/amaru) - A Cardano node client written in Rust.
 * [reth](https://github.com/paradigmxyz/reth) - Modular, contributor-friendly and blazing-fast implementation of the Ethereum protocol.
 * [revm](https://github.com/bluealloy/revm) - Revolutionary Machine (revm) is a fast Ethereum virtual machine.
-* [RustChain](https://github.com/Scottcjn/Rustchain) - A DePIN blockchain with Proof of Antiquity consensus that rewards vintage hardware with higher mining multipliers. [![GitHub Stars](https://img.shields.io/github/stars/Scottcjn/Rustchain?style=social)](https://github.com/Scottcjn/Rustchain)
+* [RustChain](https://github.com/Scottcjn/Rustchain) - Proof-of-Antiquity blockchain where old machines outmine new ones. AI-powered hardware fingerprinting rewards vintage hardware preservation.
 * [rust-bitcoin](https://github.com/rust-bitcoin/rust-bitcoin) - Library with support for de/serialization, parsing and executing on data structures and network messages related to Bitcoin.
 * [rust-lightning](https://github.com/lightningdevkit/rust-lightning) [![Crate](https://img.shields.io/crates/v/lightning.svg?logo=rust)](https://crates.io/crates/lightning) - Bitcoin Lightning library. The main crate,`lightning`, does not handle networking, persistence, or any other I/O. Thus,it is runtime-agnostic, but users must implement basic networking logic, chain interactions, and disk storage.po on linking crate.
 * [sigma-rust](https://github.com/ergoplatform/sigma-rust) - ErgoTree interpreter and wallet-related features.
@@ -517,6 +518,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 * [ShadoySV/work-break](https://github.com/ShadoySV/work-break) [[work-break](https://crates.io/crates/work-break)] - Work and rest time balancer taking into account your current and today strain [![Build](https://github.com/ShadoySV/work-break/actions/workflows/release.yml/badge.svg)](https://github.com/ShadoySV/work-break/actions/workflows/release.yml)
 * [tambourine-voice](https://github.com/kstonekuan/tambourine-voice) - personal AI voice interface for any app - customizable dictation that lets you choose your own models and prompts, built using Rust.
 * [tassiovirginio/try-rs](https://github.com/tassiovirginio/try-rs) [[try-rs](https://crates.io/crates/try-rs)] - Workspace manager CLI with a TUI to organize and navigate temporary experiments.
+* [thClaws/thClaws](https://github.com/thClaws/thClaws) - Native Rust AI agent workspace with multi-provider LLM support, skills system, MCP servers, knowledge bases, and agent orchestration. Features desktop GUI, CLI REPL, and non-interactive modes. [![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](https://github.com/thClaws/thClaws)
 * [yashs662/rust_kanban](https://github.com/yashs662/rust_kanban) [[rust-kanban](https://crates.io/crates/rust-kanban)] [![Build](https://github.com/yashs662/rust_kanban/actions/workflows/build.yml/badge.svg)](https://github.com/yashs662/rust_kanban/releases) - A Kanban App for the terminal
 
 ### Routing protocols

--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ If you want to contribute, please read [this](CONTRIBUTING.md).
 * [pragma-org/amaru](https://github.com/pragma-org/amaru) - A Cardano node client written in Rust.
 * [reth](https://github.com/paradigmxyz/reth) - Modular, contributor-friendly and blazing-fast implementation of the Ethereum protocol.
 * [revm](https://github.com/bluealloy/revm) - Revolutionary Machine (revm) is a fast Ethereum virtual machine.
+* [RustChain](https://github.com/Scottcjn/Rustchain) - A DePIN blockchain with Proof of Antiquity consensus that rewards vintage hardware with higher mining multipliers. [![GitHub Stars](https://img.shields.io/github/stars/Scottcjn/Rustchain?style=social)](https://github.com/Scottcjn/Rustchain)
 * [rust-bitcoin](https://github.com/rust-bitcoin/rust-bitcoin) - Library with support for de/serialization, parsing and executing on data structures and network messages related to Bitcoin.
 * [rust-lightning](https://github.com/lightningdevkit/rust-lightning) [![Crate](https://img.shields.io/crates/v/lightning.svg?logo=rust)](https://crates.io/crates/lightning) - Bitcoin Lightning library. The main crate,`lightning`, does not handle networking, persistence, or any other I/O. Thus,it is runtime-agnostic, but users must implement basic networking logic, chain interactions, and disk storage.po on linking crate.
 * [sigma-rust](https://github.com/ergoplatform/sigma-rust) - ErgoTree interpreter and wallet-related features.


### PR DESCRIPTION
## What
Add RustChain to the Blockchain section of awesome-rust.

## Why RustChain
- **Novel consensus**: Proof-of-Antiquity rewards vintage hardware (PowerPC G4, Sun SPARC, IBM POWER) with higher mining multipliers than modern x86_64
- **Python+Rust hybrid**: Core is Python, performance-critical paths in Rust
- **AI hardware fingerprinting**: Unique ML-based hardware identification
- **Active project**: 249 stars, 232 forks, active development

## Entry Added
```markdown
* [RustChain](https://github.com/Scottcjn/Rustchain) - Proof-of-Antiquity blockchain where old machines outmine new ones. AI-powered hardware fingerprinting rewards vintage hardware preservation.
```

## Evidence
- Repo: https://github.com/Scottcjn/Rustchain
- Website: https://rustchain.org
