### PR TITLE
Add DonutBrowser to the list of Web

### DIFF
--- a/README.md
+++ b/README.md
@@ -774,6 +774,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 * [shouya/rss-funnel](https://github.com/shouya/rss-funnel) - A modular RSS processing pipeline system.
 * [SinTan1729/Chhoto URL](https://github.com/SinTan1729/chhoto-url) - A simple, blazingly fast, selfhosted URL shortener with no unnecessary features.[![release](https://github.com/SinTan1729/chhoto-url/actions/workflows/docker-release.yml/badge.svg)](https://github.com/SinTan1729/chhoto-url/actions/workflows/docker-release.yml)
 * [Stoatchat](https://github.com/stoatchat/stoatchat) - User-first chat platform built with modern web technologies.
+* [zhom/donutbrowser](https://github.com/zhom/donutbrowser) - Open source anti-detect browser with unlimited isolated profiles, Chromium/Firefox engines, fingerprint spoofing, proxy/VPN support, local API & MCP server, and E2E encrypted cloud sync. [![GitHub release](https://img.shields.io/github/v/release/zhom/donutbrowser)](https://github.com/zhom/donutbrowser/releases)
 
 ### Web Servers
 


### PR DESCRIPTION
## Description
Add [Donut Browser](https://github.com/zhom/donutbrowser) to the Applications > Web section.

## About
Donut Browser is an open-source anti-detect browser built in Rust that provides:
-  Unlimited isolated browser profiles with unique fingerprints, cookies, and extensions
-  Dual-engine support: Chromium (via Wayfern) and Firefox (via Camoufox) with advanced fingerprint spoofing
-  Proxy & VPN support: HTTP/HTTPS/SOCKS4/SOCKS5 per profile + WireGuard configs
-  Local API & MCP server: REST API and Model Context Protocol for Claude/automation integration
-  Self-hostable cloud sync: E2E encrypted sync for profiles, proxies, and groups across devices
-  Import/export: Migrate from Chrome, Firefox, Edge, Brave; manage cookies and extensions
-  Zero telemetry: No tracking or device fingerprinting by default
-  Cross-platform: macOS (Apple Silicon/Intel), Windows, Linux (deb/rpm/AppImage)

## Criteria Check
- [x] GitHub stars: >50 (meets popularity threshold per CONTRIBUTING.md)

## Links
- Repository: https://github.com/zhom/donutbrowser
- Website: https://donutbrowser.com
- Self-hosting guide: https://github.com/zhom/donutbrowser/blob/main/docs/self-hosting-donut-sync.md
- Contributing: https://github.com/zhom/donutbrowser/blob/main/CONTRIBUTING.md