### PR TITLE
Add future-queue weighted concurrency limits for async futures

### DIFF
--- a/README.md
+++ b/README.md
@@ -1197,6 +1197,7 @@ See also [About Rust’s Machine Learning Community](https://medium.com/@autumn_
 * [dpc/mioco](https://github.com/dpc/mioco) - Scalable, coroutine-based, asynchronous IO handling library
 * [igumnoff/gabriel2](https://github.com/igumnoff/gabriel2) [[gabriel2](https://crates.io/crates/gabriel2)] - Gabriel2: An actor-model library based on Tokio
 * [mio](https://github.com/tokio-rs/mio) - MIO is a lightweight IO library, with a focus on adding as little overhead as possible over the OS abstractions
+* [nextest-rs/future-queue](https://github.com/nextest-rs/future-queue) [[future-queue](https://crates.io/crates/future-queue)] - Stream adaptors for running futures concurrently with weighted concurrency limits and optional per-group limits.
 * [rust-lang/futures-rs](https://github.com/rust-lang/futures-rs) - Zero-cost futures
 * [t3hmrman/async-dropper](https://github.com/t3hmrman/async-dropper) [[async-dropper](https://crates.io/crates/async-dropper)] - Implementation of `AsyncDrop`
 * [TeaEntityLab/fpRust](https://github.com/TeaEntityLab/fpRust) - Monad/MonadIO, Handler, Coroutine/doNotation, Functional Programming features for Rust


### PR DESCRIPTION
## Description
Add [future-queue](https://github.com/nextest-rs/future-queue) to the Libraries > Asynchronous section.

## About
future-queue provides stream adaptors for running futures concurrently with advanced concurrency control:
-  Weighted concurrency limits: Assign different "weights" to futures based on resource consumption
-  Per-group limits: Optional grouping with independent concurrency limits for each group
-  Fair scheduling: Futures are scheduled in stream order without reordering
-  Drop-in alternative: Similar API to `buffer_unordered` with enhanced flexibility
-  Battle-tested: Part of the nextest organization, designed for cargo-nextest's test runner

## Criteria Check
- [x] GitHub stars
- [x] Crates.io: `future-queue` crate published and actively maintained

## Links
- Repository: https://github.com/nextest-rs/future-queue
- Crate: https://crates.io/crates/future-queue
- Documentation: https://docs.rs/future-queue
- Changelog: https://github.com/nextest-rs/future-queue/blob/main/CHANGELOG.md