### PR TITLE
Add lean-ctx to Development tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -848,6 +848,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 * [voidzero-dev/vite-plus](https://github.com/voidzero-dev/vite-plus) - A unified web development toolchain combining Vite, Vitest, Oxlint, Rolldown, and more into a single Rust-powered CLI (`vp`)
 * [VT Code](https://crates.io/crates/vtcode) - Terminal coding agent that pairs a modern TUI with deep, semantic code understanding powered by tree-sitter and ast-grep.
 * [Wilfred/difftastic](https://github.com/Wilfred/difftastic) [[difftastic](https://crates.io/crates/difftastic)] - A structural diff tool that understands syntax, supporting 30+ programming languages
+* [yvgude/lean-ctx](https://github.com/yvgude/lean-ctx) [[lean-ctx](https://crates.io/crates/lean-ctx)] - Context runtime for AI coding agents: MCP server and shell hook that compresses tool and terminal output to reduce LLM token use; Tree-sitter parsing, session caching. [![CI](https://github.com/yvgude/lean-ctx/actions/workflows/ci.yml/badge.svg)](https://github.com/yvgude/lean-ctx/actions/workflows/ci.yml)
 
 ### Build system
 


### PR DESCRIPTION
## Summary
Adds [lean-ctx](https://github.com/yvgude/lean-ctx) ([crates.io](https://crates.io/crates/lean-ctx)) under **Development tools**, alphabetically after existing entries (by repo name).

## Inclusion
- Stars and crates.io downloads exceed CONTRIBUTING.md thresholds.

## Entry format
Matches the template: GitHub link, crates.io link, concise description, optional CI badge (consistent with similar tools in the same section).