### PR TITLE
Add oxc project to parser libraries list

### DIFF
--- a/README.md
+++ b/README.md
@@ -2012,6 +2012,7 @@ See also [Are we game yet?](https://arewegameyet.rs)
   * [m4rw3r/chomp](https://github.com/m4rw3r/chomp) - A fast monadic-style parser combinator
   * [Marwes/combine](https://github.com/Marwes/combine) - parser combinator library
   * [nrc/zero](https://github.com/nrc/zero) [[zero](https://crates.io/crates/zero/)] - zero-allocation parsing of binary data
+  * [oxc-project/oxc](https://github.com/oxc-project/oxc) [[oxc](https://crates.io/crates/oxc)] - High-performance JavaScript/TypeScript parser, transformer, minifier, and resolver written in Rust. Powers Rolldown, Nuxt, Nova, and more. [![Build Status](https://github.com/oxc-project/oxc/actions/workflows/ci.yml/badge.svg?event=push&branch=main)](https://github.com/oxc-project/oxc/actions/workflows/ci.yml)
   * [pest-parser/pest](https://github.com/pest-parser/pest) - The Elegant Parser
   * [ptal/oak](https://github.com/ptal/oak) - A typed PEG parser generator (compiler plugin)
   * [rust-bakery/nom](https://github.com/rust-bakery/nom) - parser combinator library


### PR DESCRIPTION
## Description
Add [Oxc](https://github.com/oxc-project/oxc) to the Libraries > Parsing section.

## About
Oxc (The Oxidation Compiler) is a collection of high-performance tools for JavaScript and TypeScript written in Rust:
-  Blazing fast parser with zero-copy AST and memory-efficient design
-  Transformer for TypeScript, JSX, and modern JavaScript syntax
-  Minifier for production-ready code compression
-  Resolver for module resolution compatible with Node.js and TypeScript
-  Oxlint: fast ESLint-compatible linter with 200+ rules
-  Published crates: `oxc`, `oxc_parser`, `oxc_transformer`, `oxc_minifier`, `oxc_resolver`, etc.
-  Powers real-world tools: Rolldown (Vite's future bundler), Nuxt, Nova, knip, Preact, Shopify

## Criteria Check
- [x] GitHub stars: >50 
- [x] Crates.io: `oxc` crate published and actively maintained

## Links
- Repository: https://github.com/oxc-project/oxc
- Website: https://oxc.rs
- Playground: https://playground.oxc.rs/
- Crates: https://crates.io/crates/oxc