### PR TITLE
Add balchat: pure-Rust E2E messenger over Tor onion services

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,6 +570,8 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 
 ### Social networks
 
+* Decentralized
+  * [balchat](https://github.com/xandru582/balchat) — End-to-end-encrypted (MLS / RFC 9420) 1:1 and group messenger over Tor onion services. Pure-Rust Tor stack via [arti-client](https://gitlab.torproject.org/tpo/core/arti) embedded in the app — no system Tor needed. Workspace ships a CLI, an untrusted relay, a Tauri 2 desktop app, and an Android APK. SQLCipher vault. Apache-2.0.
 * Mastodon
   * [Rustodon](https://github.com/rustodon/rustodon) - A Mastodon-compatible, ActivityPub-speaking server.
 * Telegram


### PR DESCRIPTION
## Project

[balchat](https://github.com/xandru582/balchat) — an end-to-end-encrypted 1:1 and group messenger built entirely in Rust:

- Crypto: [openmls](https://crates.io/crates/openmls) (MLS / RFC 9420)
- Transport: [arti-client](https://crates.io/crates/arti-client) onion services v3
- Storage: [rusqlite](https://crates.io/crates/rusqlite) with SQLCipher + Argon2id
- UI: [Tauri 2](https://tauri.app/) (desktop + Android)

The workspace ships 4 binaries (CLI, untrusted relay, desktop UI, Android APK) all built from the same Rust core. ~10k LOC.

## Where I added it

Under \`Applications → Social networks\`, in a new \`Decentralized\` sub-bullet (mirrors the existing \`Mastodon\` / \`Telegram\` style). Happy to move to \`Cryptography\` or another section if you'd prefer.

## Maintenance / status

Active (latest release [v0.1.3](https://github.com/xandru582/balchat/releases/tag/v0.1.3) hours ago). Apache-2.0. CI / reproducible builds in progress.

## Checklist

- [x] Has Cargo.toml at root (workspace)
- [x] Compiles on stable Rust
- [x] FOSS license (Apache-2.0)
- [x] README in English (and Spanish)
- [x] Active maintenance
- [x] Entry follows the alphabetical order of the section