### PR TITLE
Add vayou-desktop to Applications / Video

### DIFF
--- a/README.md
+++ b/README.md
@@ -750,6 +750,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 * [dertuxmalwieder/yaydl](https://github.com/dertuxmalwieder/yaydl) [[yaydl](https://crates.io/crates/yaydl)] - A simple video downloader
 * [gyroflow/gyroflow](https://github.com/gyroflow/gyroflow) - Video stabilization application using gyroscope data
 * [harlanc/xiu](https://github.com/harlanc/xiu) - A powerful and secure live server (rtmp/httpflv/hls/relay). [![crates.io](https://img.shields.io/crates/v/xiu.svg)](https://crates.io/crates/xiu)
+* [0hgawa/vayou-desktop](https://github.com/0hgawa/vayou-desktop) - Desktop video player built on libmpv via Tauri and Svelte, with multi-track subtitle translation and OpenSubtitles search.
 * [vidmerger](https://github.com/TGotwig/vidmerger) - Merge video & audio files via CLI
 * [xiph/rav1e](https://github.com/xiph/rav1e) - The fastest and safest AV1 encoder.
 


### PR DESCRIPTION
Adds [vayou-desktop](https://github.com/0hgawa/vayou-desktop) to the Applications → Video section.

vayou-desktop is a free, open-source desktop video player for Windows, built on Tauri 2 (Rust) and Svelte 5, using libmpv as the playback engine via FFI (`libloading`). The Rust portion handles the libmpv wrapper, event loop, mpv command/property interface, settings persistence, OpenSubtitles + Google Translate clients, and ffmpeg-based subtitle extraction.

Features include multi-track audio/subtitles, OpenSubtitles search, on-the-fly subtitle translation into 12 languages, a 10-band equalizer, A–B loop, file associations, and 13 UI languages.

License: MIT.

Inserted alphabetically in the Video section before `vidmerger`.