### PR TITLE
Add embassy-rs/embassy - async/await framework for embedded Rust

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ If you want to contribute, please read [this](CONTRIBUTING.md).
 
 ### Embedded
 
+* [embassy-rs/embassy](https://github.com/embassy-rs/embassy) [[embassy](https://crates.io/crates/embassy)] - Next-generation async/await framework for embedded Rust with HALs for STM32, nRF, RP, ESP32, and more. Features embassy-time, embassy-net, embassy-usb, and low-power support. [![Build Status](https://github.com/embassy-rs/embassy/actions/workflows/ci.yml/badge.svg)](https://github.com/embassy-rs/embassy/actions)
 * [rmk](https://github.com/haobogu/rmk) - A feature-rich keyboard firmware.
 * [uefi-rs](https://github.com/rust-osdev/uefi-rs) - Rusty wrapper for the Unified Extensible Firmware Interface. This crate makes it easy to develop Rust software that leverages safe, convenient, and performant abstractions for UEFI functionality.
 


### PR DESCRIPTION
## Description
Add [Embassy](https://github.com/embassy-rs/embassy) to the Applications > Embedded section.

## About
Embassy is a next-generation framework for embedded Rust applications that provides:
-  Async/await based concurrency with zero-cost state machines, no RTOS required
-  Automatic low-power sleep when idle, interrupt-driven task waking
-  embassy-time: Global, overflow-free timekeeping without hardware timer management
-  embassy-net: Full TCP/IP stack with Ethernet, IP, UDP, DHCP, ICMP support
-  embassy-usb: Device-side USB stack with CDC ACM, HID, and custom class support
-  Bluetooth LE support via trouble, nrf-softdevice, and embassy-stm32-wpan
-  embassy-boot: Power-fail-safe bootloader with trial boots and rollback support
-  HALs for STM32, nRF52/53/54/91, RP2040/23xx, MSPM0, MCX-A, ESP32, and more

## Criteria Check
- [x] GitHub stars: >50 
- [x] Crates.io: `embassy` crate published with multiple sub-crates actively maintained