### PR TITLE
Fix the arti 403's

### DIFF
--- a/README.md
+++ b/README.md
@@ -2264,10 +2264,10 @@ See also [Are we web yet?](https://www.arewewebyet.org) and [Rust web framework 
 A registry allows you to publish your Rust libraries as crate packages, to share them with others publicly and privately.
 
 * [cenotelie/cratery](https://github.com/cenotelie/cratery) - A lightweight private cargo registry with batteries included, built for organisations, including features similar to [docs.rs](https://docs.rs) and [deps.rs](https://deps.rs). [![CI](https://github.com/cenotelie/cratery/actions/workflows/ci.yml/badge.svg)](https://github.com/cenotelie/cratery/actions/workflows/ci.yml)
-* [Cloudsmith :heavy_dollar_sign:](https://cloudsmith.com/product/formats/cargo-registry) - A fully managed package management SaaS, with first-class support for public and private Cargo/Rust registries (plus many others). Has a generous free-tier and is also completely free for open-source.
+* [Cloudsmith :heavy_dollar_sign:](https://cloudsmith.com/product/formats/cargo-registry) - A fully managed package management SaaS, with first-class support for public and private Cargo/Rust registries (plus many others). Free for open-source projects.
 * [Crates](https://crates.io) - The official public registry for Rust/Cargo.
 * [getnora-io/nora](https://github.com/getnora-io/nora) - A lightweight, single-binary artifact registry supporting Docker, Maven, npm, PyPI, Cargo, Go, and raw formats. Upstream proxy with caching and air-gap mode.
-* [RepoFlow](https://www.repoflow.io) - A simple and modern repository platform that can host Rust crate repositories and proxy crates.io. Also supports other package types like Docker, PyPI, Maven, npm, and RubyGems. Available as a cloud service or self-hosted.
+* [RepoFlow :heavy_dollar_sign:](https://www.repoflow.io) - A simple and modern repository platform that can host Rust crate repositories and proxy crates.io. Also supports other package types like Docker, PyPI, Maven, npm, and RubyGems. Available as a cloud service or self-hosted.
 * [w4/chartered](https://github.com/w4/chartered) - A private, authenticated, permissioned Cargo registry [![CI](https://github.com/w4/chartered/actions/workflows/ci.yml/badge.svg)](https://github.com/w4/chartered/actions/workflows/ci.yml)
 
 ## Resources

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,6 +70,8 @@ lazy_static! {
         "https://gitlab.redox-os.org/redox-os/redox", // Cloudflare
         "https://www.modbus.org/",
         "https://portmedia.sourceforge.net/portmidi/",
+        "https://gitlab.torproject.org/tpo/core/arti",
+        "https://cloudsmith.com/product/formats/cargo-registry",
     ].iter().map(|s| s.to_string()).collect();
 
     // Overrides for popularity count, each needs a good reason (i.e. downloads/stars we don't support automatic counting of)


### PR DESCRIPTION
Tor's arti now returns 403 with a browser redirect thing, so just skip it.