### PR TITLE
Add auralis — async-first reactive signals + structured concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1840,6 +1840,7 @@ See also [Are we game yet?](https://arewegameyet.rs)
 * [autopilot-rs/autopilot-rs](https://github.com/autopilot-rs/autopilot-rs) - A simple, cross-platform GUI automation library.
 * Cocoa
   * [servo/core-foundation-rs](https://github.com/servo/core-foundation-rs) - Rust bindings to Core Foundation and other low level libraries on Mac OS X and iOS
+* [chh-itt/auralis](https://github.com/chh-itt/auralis) [[auralis-signal](https://crates.io/crates/auralis-signal)] - Async-first reactive signals and structured concurrency, zero dependencies, zero unsafe. [![CI](https://github.com/chh-itt/auralis/actions/workflows/ci.yml/badge.svg)](https://github.com/chh-itt/auralis/actions/workflows/ci.yml)
 * [DioxusLabs/dioxus](https://github.com/dioxuslabs/dioxus) - a portable, performant, and ergonomic framework for building cross-platform user interfaces in Rust. ![rust ci](https://github.com/dioxuslabs/dioxus/actions/workflows/main.yml/badge.svg)
 * [emilk/egui](https://github.com/emilk/egui) - Simple, fast, and highly portable immediate mode GUI library. egui runs on the web, natively, and in your favorite game engine. [![Build Status](https://github.com/emilk/egui/workflows/CI/badge.svg)](https://github.com/emilk/egui/actions?workflow=CI)
 * [emoon/rust_minifb](https://github.com/emoon/rust_minifb) - minifb is a cross-platform window setup with optional bitmap rendering. It also comes with easy mouse and keyboard input. Primarily designed for prototyping


### PR DESCRIPTION
[Auralis](https://github.com/chh-itt/auralis) is an async-first reactive kernel for Rust.

  - Two crates: `auralis-signal` (Signal<T>, Memo<T>, SignalMap) and `auralis-task` (TaskScope, priority executor,
  timer)
  - `auralis-signal` has **zero dependencies**, `auralis-task` depends only on `auralis-signal`
  - `#![forbid(unsafe_code)]` in both crates — **zero unsafe code**
  - Reactive = pausable async tasks; lifecycle = ownership + structured concurrency
  - Used with egui (see [demo](https://github.com/chh-itt/auralis/tree/main/demos/egui-demo))

  Placed under GUI section as reactive signal libraries are primarily used in GUI contexts.