### PR TITLE
Add bufjson crate to JSON section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1682,6 +1682,7 @@ See also [About Rust’s Machine Learning Community](https://medium.com/@autumn_
   * [rustadopt/jzon-rs](https://github.com/rustadopt/jzon-rs/) [[jzon](https://crates.io/crates/jzon)] - JSON implementation
   * [serde-rs/json](https://github.com/serde-rs/json) [[serde\_json](https://crates.io/crates/serde_json)] - JSON support for [Serde](https://github.com/serde-rs/serde) framework
   * [simd-lite/simd-json](https://github.com/simd-lite/simd-json) [[simd-json](https://crates.io/crates/simd-json)] - High performance JSON parser based on a port of simdjson
+  * [vcschapp/bufjson](https://github.com/vcschapp/bufjson) [[bufjson](https://crates.io/crates/bufjson)] - Streaming JSON parser and lexer, no copy/no allocation, optional streaming JSON Pointer evaluator
 * MsgPack
   * [3Hren/msgpack-rust](https://github.com/3Hren/msgpack-rust) - Low/high level MessagePack implementation
 * NetCDF


### PR DESCRIPTION
# Description

This change adds the [bufjson](https://crates.io/crates/bufjson) crate to the JSON section of the `README.md`.

# Acceptance Criteria

1. Exceeds the 2,000 downloads threshold (3,520).
2. The crate is differentiated from the other JSON listings, and differentiated in the JSON parsing category.
   - It is a lower-level pull parser with a streaming-first design.
   - It aims to do all parsing with low-to-zero copies and low-to-zero allocations (whether it is low or zero depends on the specific use case).
   - As far as I can tell it is one of the faster, if not the fastest, streaming-oriented parser offered on `crates.io`.
   - It is the only crate with a fully streaming JSON Pointer evaluator.

