### PR TITLE
Add FerrisMind/shadcn-rs to GUI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1844,6 +1844,7 @@ See also [Are we game yet?](https://arewegameyet.rs)
 * [DioxusLabs/dioxus](https://github.com/dioxuslabs/dioxus) - a portable, performant, and ergonomic framework for building cross-platform user interfaces in Rust. ![rust ci](https://github.com/dioxuslabs/dioxus/actions/workflows/main.yml/badge.svg)
 * [emilk/egui](https://github.com/emilk/egui) - Simple, fast, and highly portable immediate mode GUI library. egui runs on the web, natively, and in your favorite game engine. [![Build Status](https://github.com/emilk/egui/workflows/CI/badge.svg)](https://github.com/emilk/egui/actions?workflow=CI)
 * [emoon/rust_minifb](https://github.com/emoon/rust_minifb) - minifb is a cross-platform window setup with optional bitmap rendering. It also comes with easy mouse and keyboard input. Primarily designed for prototyping
+* [FerrisMind/shadcn-rs](https://github.com/FerrisMind/shadcn-rs) [[iced-shadcn](https://crates.io/crates/iced-shadcn)] - iced and egui component set with shadcn/ui aesthetics; includes [egui-shadcn](https://crates.io/crates/egui-shadcn).
 * [FLTK](https://www.fltk.org/)
   * [fltk-rs](https://github.com/fltk-rs/fltk-rs) - FLTK bindings [![Build](https://github.com/fltk-rs/fltk-rs/workflows/Build/badge.svg?branch=master)](https://github.com/fltk-rs/fltk-rs/actions)
 * [Flutter](https://flutter.dev/)


### PR DESCRIPTION
## Summary
Add `FerrisMind/shadcn-rs` to `Libraries -> GUI` in `README.md`.

Added entry:
`[FerrisMind/shadcn-rs](https://github.com/FerrisMind/shadcn-rs) [[iced-shadcn](https://crates.io/crates/iced-shadcn)] - iced and egui component set with shadcn/ui aesthetics; includes [egui-shadcn](https://crates.io/crates/egui-shadcn).`

## Contributing Checklist
- Popularity threshold: GitHub stars are **51** (checked on **May 13, 2026**), which satisfies `stars > 50`.
- Template: entry follows `[ACCOUNT/REPO](...) [[CRATE](...)] - DESCRIPTION`.
- Sorting: placed alphabetically in the GUI list (between `emoon/rust_minifb` and `FLTK`).

## Scope
- Only `README.md` was changed.
