### PR TITLE
Add geojson library to Geospatial

### DIFF
--- a/README.md
+++ b/README.md
@@ -1802,6 +1802,7 @@ See also [Are we game yet?](https://arewegameyet.rs)
 * [apache/sedona-db](https://github.com/apache/sedona-db) - SedonaDB is a geospatial DataFrame library written in Rust.
 * [DaveKram/coord_transforms](https://github.com/DaveKram/coord_transforms) [[coord_transforms](https://crates.io/crates/coord_transforms)] - coordinate transformations (2-d, 3-d, and geospatial)
 * [Georust](https://github.com/georust) - geospatial tools and libraries written
+* [georust/geojson](https://github.com/georust/geojson) [[geojson](https://crates.io/crates/geojson)] - Library for serializing and deserializing the GeoJSON vector GIS file format.
 * [MapLibre/Martin](https://github.com/maplibre/martin) - Map tile server with PostGIS, MBTiles, PMTiles, and sprites support. [![CI build](https://github.com/maplibre/martin/actions/workflows/ci.yml/badge.svg)](https://github.com/maplibre/martin/actions)[![crates.io version](https://img.shields.io/crates/v/martin.svg)](https://crates.io/crates/martin)[![Book](https://img.shields.io/badge/docs-Book-informational)](https://maplibre.org/martin/)
 * [rust-reverse-geocoder](https://github.com/gx0r/rrgeo) - A fast, offline reverse geocoder, inspired by [thampiman/reverse-geocoder](https://github.com/thampiman/reverse-geocoder)
 * [vlopes11/geomorph](https://github.com/vlopes11/geomorph) [[geomorph](https://crates.io/crates/geomorph)] - conversion between UTM, LatLon and MGRS coordinates


### PR DESCRIPTION
## Description
Add [geojson](https://github.com/geojson-rs/geojson) to the Libraries > Geospatial section.

## About
geojson is a library for serializing and deserializing the GeoJSON vector GIS file format that provides:
-  Full support for GeoJSON Features, Geometries, and FeatureCollections
-  Parse GeoJSON from strings with `geojson_str.parse::<GeoJson>()`
-  Serialize GeoJson structs back to string representation
-  Support for properties, bounding boxes, IDs, and foreign members
-  Written in pure Rust with no external dependencies for core functionality
-  Well-documented with examples for reading and writing

## Criteria Check
- [x] GitHub stars: >50
- [x] Crates.io: `geojson` crate published and actively maintained