### PR TITLE
Add gtk-rs/gir - code generator for GObject-based Rust bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -952,6 +952,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 See also [Foreign Function Interface](https://doc.rust-lang.org/book/first-edition/ffi.html), [The Rust FFI Omnibus](http://jakegoulding.com/rust-ffi-omnibus/) (a collection of examples of using code written in Rust from other languages) and [FFI examples written in Rust](https://github.com/alexcrichton/rust-ffi-examples).
 
 * C
+  * [gtk-rs/gir](https://github.com/gtk-rs/gir) - Code generator for creating safe Rust bindings from GObject-based C libraries.
   * [mozilla/cbindgen](https://github.com/mozilla/cbindgen) - generates C header files from Rust source files. Used in Gecko for WebRender
   * [Sean1708/rusty-cheddar](https://github.com/Sean1708/rusty-cheddar) - generates C header files from Rust source files
 * C#


### PR DESCRIPTION
## Description
Add [GIR](https://github.com/gtk-rs/gir) to the Development tools > FFI section.

## About
GIR (GObject Introspection Repository) is a code generator that creates safe Rust bindings for GObject-based C libraries:
-  Generates both low-level FFI bindings (unsafe C API) and high-level safe Rust API
-  Used by the gtk-rs ecosystem to bind GTK, GDK, GLib, and other GObject libraries
-  Supports introspection data from .gir files (GObject Introspection format)
-  Configurable via TOML files to customize binding generation
-  Helps bring GNOME/GTK ecosystem to Rust with type-safe APIs

## Criteria Check
- [x] GitHub stars: > 50
