### PR TITLE
docs: add RustChain to awesome-rust

### DIFF
--- a/README.md
+++ b/README.md
@@ -2344,3 +2344,4 @@ A registry allows you to publish your Rust libraries as crate packages, to share
 ## License
 
 [![CC0](https://licensebuttons.net/p/zero/1.0/88x31.png)](https://creativecommons.org/publicdomain/zero/1.0/)
+- [RustChain](https://github.com/Scottcjn/Rustchain) - Proof-of-Antiquity blockchain that rewards vintage hardware. Old computers earn more than new ones.


### PR DESCRIPTION
Adds [RustChain](https://github.com/Scottcjn/Rustchain) to this awesome list.

Proof-of-Antiquity blockchain that rewards vintage hardware. Old computers earn more than new ones.

Closes rustchain-bounties#2862
