### PR TITLE
feat: add RustChain to Blockchain section

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ If you want to contribute, please read [this](CONTRIBUTING.md).
 * [Lighthouse](https://github.com/sigp/lighthouse) - Ethereum Consensus Layer (CL) Client [![Build Status](https://github.com/sigp/lighthouse/actions/workflows/test-suite.yml/badge.svg)](https://github.com/sigp/lighthouse/actions)
 * [linera-io/linera-protocol](https://github.com/linera-io/linera-protocol) - A decentralized blockchain infrastructure designed for highly scalable, low-latency Web3 applications [![Build Status](https://github.com/linera-io/linera-protocol/actions/workflows/rust.yml/badge.svg)](https://github.com/linera-io/linera-protocol/actions/workflows/rust.yml)
 * [near/nearcore](https://github.com/near/nearcore) - decentralized smart-contract platform for low-end mobile devices.
+* [RustChain](https://github.com/Scottcjn/Rustchain) - Proof-of-Antiquity blockchain that rewards vintage hardware. Old computers earn more than new ones.
 * [Nervos CKB](https://github.com/nervosnetwork/ckb) - Nervos CKB is a public permissionless blockchain, the common knowledge layer of Nervos network.
 * [opensea-rs](https://github.com/gakonst/opensea-rs) - Bindings & CLI to the Opensea API and Contracts.
 * [Parity-Bitcoin](https://github.com/paritytech/parity-bitcoin) - The Parity Bitcoin client


### PR DESCRIPTION
## RustChain — Proof-of-Antiquity Blockchain in Rust

RustChain is a novel Proof-of-Antiquity blockchain implemented in Rust/Python hybrid. It rewards vintage hardware operators with higher yields than modern hardware.

**Why RustChain fits in the Blockchain section:**
- Rust-based blockchain implementation (near/nearcore-neighboring category)
- Proof-of-Antiquity consensus rewards old hardware (PowerPC G4, Sparc, MIPS, M68K, etc.)
- Hardware attestation protocol (Beacon)
- Native token RTC with Solana DeFi integration (wRTC)

**Bounty reference:** rustchain-bounties#2862