### PR TITLE
Add Waveshare smartwatch firmware

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ If you want to contribute, please read [this](CONTRIBUTING.md).
 ### Embedded
 
 * [embassy-rs/embassy](https://github.com/embassy-rs/embassy) [[embassy](https://crates.io/crates/embassy)] - Next-generation async/await framework for embedded Rust with HALs for STM32, nRF, RP, ESP32, and more. Features embassy-time, embassy-net, embassy-usb, and low-power support. [![Build Status](https://github.com/embassy-rs/embassy/actions/workflows/ci.yml/badge.svg)](https://github.com/embassy-rs/embassy/actions)
+* [infinition/waveshare-watch-rs](https://github.com/infinition/waveshare-watch-rs) - 100% Rust `no_std` smartwatch firmware for Waveshare ESP32-S3-Touch-AMOLED-2.06. Features QSPI 80 MHz DMA display, Embassy async runtime, event-driven power management with Always-On Display.
 * [rmk](https://github.com/haobogu/rmk) - A feature-rich keyboard firmware.
 * [uefi-rs](https://github.com/rust-osdev/uefi-rs) - Rusty wrapper for the Unified Extensible Firmware Interface. This crate makes it easy to develop Rust software that leverages safe, convenient, and performant abstractions for UEFI functionality.
 


### PR DESCRIPTION
- [ ] - I have read the [CONTRIBUTING.md](CONTRIBUTING.md) and my pull request fulfills the criteria therein

## Description
Add [waveshare-watch-rs](https://github.com/infinition/waveshare-watch-rs) to the Applications > Embedded section.

## About
waveshare-watch-rs is a complete smartwatch firmware written in 100% Rust (`no_std`) for the Waveshare ESP32-S3-Touch-AMOLED-2.06 board:
-  Pure Rust implementation with zero C code or ESP-IDF components in the final binary
-  Embassy async runtime + esp-hal 1.0 for peripherals (QSPI, I2C, I2S, DMA, PSRAM)
-  410×502 AMOLED display at 80 MHz QSPI DMA with double-buffered framebuffer + VSync anti-tearing
-  Event-driven power management: 4-level sleep/wake states + Apple Watch-style Always-On Display
-  5 mini-games (Snake, 2048, Tetris, Flappy, Maze) + launcher + T9 keyboard + MP3 player UI
-  WiFi + NTP sync via embassy-net (smoltcp), HTTP client, auto-disconnect idle
-  ES8311 audio codec + I2S DMA for beep feedback
-  QMI8658 IMU (accel/gyro) + FT3168 touch + PCF85063A RTC + AXP2101 power management
-  ~579 KB release binary, 64 KB SRAM heap + 8 MB PSRAM heap

## Criteria Check
- [x] GitHub stars: > 50
