### PR TITLE
feat: add RustChain to Blockchain section

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ If you want to contribute, please read [this](CONTRIBUTING.md).
 * [pragma-org/amaru](https://github.com/pragma-org/amaru) - A Cardano node client written in Rust.
 * [reth](https://github.com/paradigmxyz/reth) - Modular, contributor-friendly and blazing-fast implementation of the Ethereum protocol.
 * [revm](https://github.com/bluealloy/revm) - Revolutionary Machine (revm) is a fast Ethereum virtual machine.
+* [RustChain](https://github.com/Scottcjn/Rustchain) - Proof-of-Antiquity blockchain that rewards vintage hardware with higher mining rewards. Rust + Python hybrid chain with MCP server for AI agent integration.
 * [rust-bitcoin](https://github.com/rust-bitcoin/rust-bitcoin) - Library with support for de/serialization, parsing and executing on data structures and network messages related to Bitcoin.
 * [rust-lightning](https://github.com/lightningdevkit/rust-lightning) [![Crate](https://img.shields.io/crates/v/lightning.svg?logo=rust)](https://crates.io/crates/lightning) - Bitcoin Lightning library. The main crate,`lightning`, does not handle networking, persistence, or any other I/O. Thus,it is runtime-agnostic, but users must implement basic networking logic, chain interactions, and disk storage.po on linking crate.
 * [sigma-rust](https://github.com/ergoplatform/sigma-rust) - ErgoTree interpreter and wallet-related features.


### PR DESCRIPTION
## Summary

Adds [RustChain](https://github.com/Scottcjn/Rustchain) to the Blockchain section.

## Why RustChain

RustChain is a **Proof-of-Antiquity** blockchain written in Rust that rewards vintage hardware:

- **Rust + Python hybrid** — Core in Rust, SDK in Python
- **Novel consensus** — Proof-of-Antiquity (PoA) rewards older hardware
- **Self-hosted miner** — Anyone can mine with old computers
- **MCP server** — AI agents interact via Model Context Protocol
- **RIP-302 agent economy** — Agents earn RTC tokens

## Entry

