### PR TITLE
Add RustChain — DePIN for Vintage Hardware

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ If you want to contribute, please read [this](CONTRIBUTING.md).
 * [CITA](https://github.com/citahub/cita) - A high performance blockchain kernel for enterprise users.
 * [coinbase-pro-rs](https://github.com/inv2004/coinbase-pro-rs) - Coinbase pro client, supports sync/async/websocket
 * [datahaven-xyz/datahaven](https://github.com/datahaven-xyz/datahaven) - AI-First Decentralized Storage secured by EigenLayer.
+* [RustChain](https://github.com/Scottcjn/Rustchain) - DePIN for Vintage Hardware — AI-Augmented Proof of Real Machines
 * [Diem](https://github.com/diem/diem) - Diem’s mission is to enable a simple global currency and financial infrastructure that empowers billions of people.
 * [dusk-network/rusk](https://github.com/dusk-network/rusk) - Reference implementation of Dusk, a privacy-focused, scalable FMI for real-world assets (RWA) and compliant financial applications. [![Build Status](https://github.com/dusk-network/rusk/actions/workflows/rusk_ci.yml/badge.svg)](https://github.com/dusk-network/rusk/actions/workflows/rusk_ci.yml)
 * [electrumrs](https://github.com/romanz/electrs) - An efficient re-implementation of Electrum Server.


### PR DESCRIPTION
## Add RustChain to Awesome Rust

RustChain — DePIN for Vintage Hardware — AI-Augmented Proof of Real Machines

- **GitHub:** https://github.com/Scottcjn/Rustchain
- **Website:** https://rustchain.org
- **Description:** DePIN for Vintage Hardware — AI-Augmented Proof of Real Machines
- **Tags:** DePIN, blockchain, AI agents, Rust, vintage hardware, Proof of Antiquity

---
Bounty #2862
Wallet: RTC502709aa4bcbc4e19001fe3808afb71aa23d19b6