### PR TITLE
Add fff library to file operations section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1727,6 +1727,7 @@ See also [About Rust’s Machine Learning Community](https://medium.com/@autumn_
 [[filesystem](https://crates.io/keywords/filesystem)]
 * Operations
   * [Camino](https://github.com/camino-rs/camino) [[camino](https://crates.io/crates/camino)] - Like Rust's std::path::Path, but UTF-8.
+  * [dmtrKovalenko/fff](https://github.com/dmtrKovalenko/fff) [[fff-search](https://crates.io/crates/fff-search)] - Typo-resistant file and content search library with frecency ranking, git-aware annotations, background watcher, and lightweight in-memory content index. Provides MCP server, Node/Bun SDK, C library, and Neovim plugin.
   * [dnbln/dir-structure](https://github.com/dnbln/dir-structure) [[dir-structure](https://crates.io/crates/dir-structure)] - Model file system trees with plain Rust structures. [![Tests](https://github.com/dnbln/dir-structure/actions/workflows/test-dir-structure.yml/badge.svg?branch=trunk)](https://github.com/dnbln/dir-structure/actions/workflows/test-dir-structure.yml)
   * [OpenDAL](https://github.com/apache/opendal) [[opendal](https://crates.io/crates/opendal)] - A unified data access layer, empowering users to seamlessly and efficiently retrieve data from diverse storage services. [![build](https://img.shields.io/github/actions/workflow/status/apache/opendal/ci_core.yml?branch=main)](https://github.com/apache/opendal/actions?query=branch%3Amain)
   * [ParthJadhav/Rust_Search](https://github.com/ParthJadhav/Rust_Search) [[rust_search](https://crates.io/crates/rust_search)] - Blazingly fast file search library.


### PR DESCRIPTION
- [ ] - I have read the [CONTRIBUTING.md](CONTRIBUTING.md) and my pull request fulfills the criteria therein

## Description
Add [fff](https://github.com/dmtrKovalenko/fff) to the Libraries > Filesystem section.

## About
FFF is a high-performance file search toolkit written in Rust that provides:
-  Typo-resistant fuzzy matching for both paths and content using SIMD-accelerated algorithms
-  Frecency-ranked results: files you open frequently rank higher in searches
-  Git-aware annotations: modified, staged, untracked, and ignored status cached and returned with results
-  Background file watcher for incremental re-indexing without full rescans
-  Lightweight in-memory content index (~360 bytes/file) for sub-10ms grep queries
-  Multi-language bindings: Rust crate (`fff-search`), C library (`libfff_c`), Node/Bun SDK (`@ff-labs/fff-node`)
-  MCP server for AI agents (Claude Code, Codex, Cursor, Cline) with `ffgrep`, `fffind`, `fff-multi-grep` tools
-  Neovim plugin (`fff.nvim`) with interactive picker, live grep modes, and multi-select support

## Criteria Check
- [x] GitHub stars: > 50
- [x] Crates.io: `fff-search` crate published and actively maintained