### PR TITLE
Add museslabs/phonto - GPU accelerated video wallpaper program

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,7 @@ See also [Games Made With Piston](https://github.com/PistonDevelopers/piston/wik
 * [KaminariOS/rustracer](https://github.com/KaminariOS/rustracer) - A PBR glTF 2.0 renderer based on Vulkan ray-tracing.
 * [Limeth/euclider](https://github.com/Limeth/euclider) - A real-time 4D CPU ray tracer
 * [linebender/resvg](https://github.com/linebender/resvg) - An SVG rendering library.
+* [museslabs/phonto](https://github.com/museslabs/phonto) - GPU-accelerated video wallpaper program for Wayland and macOS, written in Rust.
 * [rodrigorc/papercraft](https://github.com/rodrigorc/papercraft) - A tool to unwrap 3D models and create them in paper with scissors and glue.
 * [rustq/vue-skia](https://github.com/rustq/vue-skia) - Skia based 2d graphics vue rendering library. It is based on Rust to implement software rasterization to perform rendering.
 * [storytold/artcraft](https://github.com/storytold/artcraft) - An AI-powered IDE and tangible computing surface for molding scenes, videos, and images like clay.


### PR DESCRIPTION
- [ ] - I have read the [CONTRIBUTING.md](CONTRIBUTING.md) and my pull request fulfills the criteria therein

## Description
Add [phonto](https://github.com/museslabs/phonto) to the Applications > Graphics section.

## About
Phonto is a GPU-accelerated video wallpaper program written in Rust that provides:
-  Play video files as desktop background on Wayland compositors and macOS
-  Minimal CPU overhead via GPU decoding (VA-API on Linux, VideoToolbox on macOS) and rendering (EGL/CoreAnimation)
-  GLSL ES 3.00 shader support for custom per-frame effects on Wayland
-  Live lockscreen wallpaper support on macOS via aerial catalog integration
-  Random wallpaper selection with configurable search paths and depth
-  Battery-aware playback: pause on battery or below charge threshold
-  Hyprlock integration on Wayland: render video on overlay layer behind lock screen
-  Available via Nix, Homebrew, AUR, and crates.io

## Criteria Check
- [x] GitHub stars: > 50