### PR TITLE
Add rav2d - AV2 video decoder ported from C to Rust

### DIFF
--- a/README.md
+++ b/README.md
@@ -2174,6 +2174,7 @@ See also [Are we game yet?](https://arewegameyet.rs)
 ### Video
 
 * [ffmpeg-sidecar](https://github.com/nathanbabcock/ffmpeg-sidecar) - Wrap a standalone FFmpeg binary in an intuitive Iterator interface. [![Build Status](https://github.com/nathanbabcock/ffmpeg-sidecar/actions/workflows/ci.yml/badge.svg)](https://github.com/nathanbabcock/ffmpeg-sidecar/actions)
+* [rav2d](https://github.com/stukenov/rav2d) - Memory-safe AV2 video decoder, ported from dav2d (C) to Rust. Assembly DSP kernels via FFI, all C decoder logic in safe Rust.
 * [screencapturekit-rs](https://github.com/doom-fish/screencapturekit-rs) [[screencapturekit](https://crates.io/crates/screencapturekit)] - Safe Rust bindings for Apple's ScreenCaptureKit framework for macOS screen/audio capture [![Build Status](https://github.com/doom-fish/screencapturekit-rs/actions/workflows/ci.yml/badge.svg)](https://github.com/doom-fish/screencapturekit-rs/actions)
 
 ### Virtualization


### PR DESCRIPTION
## What

Adding [rav2d](https://github.com/stukenov/rav2d) to the Video section.

## Description

**rav2d** is a complete Rust port of [dav2d](https://code.videolan.org/videolan/dav2d), the AV2 video decoder:

- 47,000+ lines of Rust across 47 source files
- 786 unit tests passing
- All C decoder logic ported to safe Rust
- Assembly DSP kernels shared via FFI (not rewritten)
- Full pipeline: OBU parsing, entropy decoding, block decode, deblock, CDEF, loop restoration, film grain, motion compensation, inverse transforms, threading

Follows the same approach as [rav1d](https://github.com/memorysafety/rav1d) (AV1 Rust port).

Licensed BSD 2-Clause (same as dav2d).