### PR TITLE
Add pdf-inspector - fast PDF classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -2030,6 +2030,7 @@ See also [Are we game yet?](https://arewegameyet.rs)
   * [cchexcode/wavefront_rs](https://github.com/cchexcode/wavefront_rs) - A parser for the Wavefront OBJ format. [![crates.io](https://img.shields.io/crates/v/wavefront_rs.svg)](https://crates.io/crates/wavefront_rs) [![crates.io](https://img.shields.io/crates/d/wavefront_rs?label=crates.io%20downloads)](https://crates.io/crates/wavefront_rs) [![build badge](https://github.com/cchexcode/wavefront_rs/workflows/pipeline/badge.svg?branch=master)](https://github.com/cchexcode/wavefront_rs/actions)
   * [comex/rust-shlex](https://github.com/comex/rust-shlex) [[shlex](https://crates.io/crates/shlex)] - Split a string into shell words, like Python's shlex. [![build badge](https://github.com/comex/rust-shlex/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/comex/rust-shlex/actions/workflows/test.yml)
   * [Eliah-Lakhin/lady-deirdre](https://github.com/Eliah-Lakhin/lady-deirdre) - A framework for new programming languages and LSP servers.
+  * [firecrawl/pdf-inspector](https://github.com/firecrawl/pdf-inspector) - Fast Rust library for PDF classification and text extraction.
   * [Folyd/robotstxt](https://github.com/Folyd/robotstxt) - Port of Google's robots.txt parser and matcher C++ library
   * [freestrings/jsonpath](https://github.com/freestrings/jsonpath) - [JsonPath](https://goessner.net/articles/JsonPath/) engine. Webassembly and Javascript support too
   * [hmeyer/stl_io](https://crates.io/crates/stl_io) - A parser for STL (STereoLithography) files


### PR DESCRIPTION
- [ ] - I have read the [CONTRIBUTING.md](CONTRIBUTING.md) and my pull request fulfills the criteria therein

## Description
Add [pdf-inspector](https://github.com/firecrawl/pdf-inspector) to the Libraries > Parsing section.

## About
pdf-inspector is a high-performance Rust library for PDF analysis and text extraction that provides:
-  Ultra-fast classification (~10-50ms) detecting TextBased, Scanned, ImageBased, or Mixed PDFs with confidence scores
-  Position-aware text extraction with font info, X/Y coordinates, and automatic multi-column reading order
-  Smart Markdown conversion: headings (H1-H4), lists, code blocks, tables, bold/italic, URLs, and page breaks
-  Dual-mode table detection: rectangle-based from PDF drawing ops + heuristic alignment-based detection
-  Full CID font support: ToUnicode CMap decoding for Type0/Identity-H fonts, UTF-16BE, UTF-8, and Latin-1
-  Multi-language bindings: Python (PyO3) and Node.js (napi-rs) alongside the core Rust API
-  Single document load: parsed once and shared between detection/extraction, avoiding redundant I/O
-  Pure Rust implementation: no ML models, no external services, single dependency on `lopdf`

## Criteria Check
- [x] Written in Rust: 98.6% Rust codebase with PyO3 and napi-rs bindings
- [x] GitHub stars: > 50