### PR TITLE
Add konippi/servo-fetch - self-contained browser engine for web extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -784,6 +784,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 * [janreges/siteone-crawler](https://github.com/janreges/siteone-crawler) [[siteone-crawler](https://crates.io/crates/siteone-crawler)] - All-in-one
    website crawler, auditor, offline archiver, and AI-ready markdown exporter with CI/CD quality gating
   [![CI](https://github.com/janreges/siteone-crawler/workflows/CI/badge.svg)](https://github.com/janreges/siteone-crawler/actions)
+* [konippi/servo-fetch](https://github.com/konippi/servo-fetch) - A self-contained browser engine that fetches, renders, and extracts web content as Markdown, JSON, or screenshots — no Chromium, no API key. CLI, Python, MCP server. [![CI](https://github.com/konippi/servo-fetch/actions/workflows/ci.yml/badge.svg)](https://github.com/konippi/servo-fetch/actions/workflows/ci.yml)
 * [LemmyNet/lemmy](https://github.com/LemmyNet/lemmy) - A link aggregator / reddit clone for the fediverse [![Build Status](https://cloud.drone.io/api/badges/LemmyNet/lemmy/status.svg)](https://cloud.drone.io/LemmyNet/lemmy)
 * [MASQ-Project/Node](https://github.com/MASQ-Project/Node) - MASQ Node software provides a decentralized mesh-network of nodes for global users to access normal internet content - next evolution of tech beyond Tor & VPN [![build badge](https://github.com/MASQ-Project/Node/actions/workflows/ci-matrix.yml/badge.svg)](https://github.com/MASQ-Project/Node/actions)
 * [Plume-org/Plume](https://github.com/Plume-org/Plume) - ActivityPub federating blogging application


### PR DESCRIPTION
- [x] - I have read the [CONTRIBUTING.md](CONTRIBUTING.md) and my pull request fulfills the criteria therein

## Description
Add [servo-fetch](https://github.com/konippi/servo-fetch) to the Applications > Web section.

## About
servo-fetch is a self-contained browser engine for fetching, rendering, and extracting web content, written in Rust:

- **No Chromium**: Powered by [Servo](https://github.com/servo/servo) — no Chrome download, no headless browser dependency.
- **Multiple outputs**: Markdown, JSON, and screenshots from a single CLI invocation.
- **Multi-distribution**: CLI binary (`cargo install servo-fetch-cli` or pre-built binaries for 5 targets), Python wheel (`pip install servo-fetch`), and Docker image (`ghcr.io/konippi/servo-fetch`).
- **AI-first design**: Built-in MCP (Model Context Protocol) server for use with LLM agents.

## Criteria Check
- [x] Written in Rust: 100% Rust workspace (3 crates)
- [x] GitHub stars: 106 (> 50 threshold)