### PR TITLE
feat: add longbridge-terminal (AI-native financial markets CLI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,9 +388,9 @@ See also [Payments](#payments) applications.
 
 * [Ashutosh0x/rust-finance](https://github.com/Ashutosh0x/rust-finance) - AI trading terminal with multi-exchange ingestion, execution, risk models, and TUI dashboard.
 * [klirr](https://github.com/Sajjon/klirr) [[klirr](https://crates.io/crates/klirr)] - Zero-maintenance and smart FOSS generating beautiful invoices for services and expenses.
+* [longbridge/longbridge-terminal](https://github.com/longbridge/longbridge-terminal) - AI-native CLI for Longbridge Securities: real-time quotes, portfolio, trading for HK/US/A-share/SG.
 * [nautechsystems/nautilus_trader](https://github.com/nautechsystems/nautilus_trader) - A high-performance, production-grade algorithmic trading platform written in Rust and Python.
 * [tackler](https://github.com/tackler-ng/tackler) [[tackler](https://crates.io/crates/tackler)] - Fast, reliable bookkeeping engine with native GIT SCM support for plain text accounting [![CI Badge](https://github.com/tackler-ng/tackler/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/tackler-ng/tackler/blob/main/.github/workflows/ci.yml)
-* [longbridge/longbridge-terminal](https://github.com/longbridge/longbridge-terminal) - AI-native CLI for Longbridge Securities: real-time quotes, portfolio, trading for HK/US/A-share/SG.
 * [tarkah/tickrs](https://github.com/tarkah/tickrs) - Realtime ticker data in your terminal
 
 ### Games

--- a/README.md
+++ b/README.md
@@ -390,6 +390,7 @@ See also [Payments](#payments) applications.
 * [klirr](https://github.com/Sajjon/klirr) [[klirr](https://crates.io/crates/klirr)] - Zero-maintenance and smart FOSS generating beautiful invoices for services and expenses.
 * [nautechsystems/nautilus_trader](https://github.com/nautechsystems/nautilus_trader) - A high-performance, production-grade algorithmic trading platform written in Rust and Python.
 * [tackler](https://github.com/tackler-ng/tackler) [[tackler](https://crates.io/crates/tackler)] - Fast, reliable bookkeeping engine with native GIT SCM support for plain text accounting [![CI Badge](https://github.com/tackler-ng/tackler/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/tackler-ng/tackler/blob/main/.github/workflows/ci.yml)
+* [longbridge/longbridge-terminal](https://github.com/longbridge/longbridge-terminal) - AI-native CLI for Longbridge Securities: real-time quotes, portfolio, trading for HK/US/A-share/SG.
 * [tarkah/tickrs](https://github.com/tarkah/tickrs) - Realtime ticker data in your terminal
 
 ### Games


### PR DESCRIPTION
## Description

Add [longbridge-terminal](https://github.com/longbridge/longbridge-terminal) to the **Finance** section.

## What is longbridge-terminal?

An AI-native CLI for Longbridge Securities built in Rust. It provides real-time market data, portfolio management, and trading for HK / US / A-share / SG markets with a TUI dashboard.

- **Language**: Rust
- **Stars**: 837
- **Repo**: https://github.com/longbridge/longbridge-terminal

## Checklist

- [x] Added in alphabetical order within the Finance section
- [x] Description is concise and accurate
- [x] Link is correct and points to the GitHub repo