### PR TITLE
Add pixtuoid: terminal pixel-art office for AI coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -730,6 +730,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 * [fcsonline/tmux-thumbs](https://github.com/fcsonline/tmux-thumbs) - A lightning fast version of tmux-fingers, copy/pasting tmux like vimium/vimperator.
 * [gitlogue](https://github.com/unhappychoice/gitlogue) - A TUI screensaver that visualizes Git commit history in your terminal
 * [guoxbin/dtool](https://github.com/guoxbin/dtool) - A useful command-line tool collection to assist development including conversion, codec, hashing, encryption, etc.
+* [IvanWng97/pixtuoid](https://github.com/IvanWng97/pixtuoid) [[pixtuoid](https://crates.io/crates/pixtuoid)] - Terminal pixel-art office that visualizes Claude Code sessions as animated coworkers in real time. [![CI](https://img.shields.io/github/actions/workflow/status/IvanWng97/pixtuoid/ci.yml?branch=main)](https://github.com/IvanWng97/pixtuoid/actions/workflows/ci.yml)
 * [Linus-Mussmaecher/rucola](https://github.com/Linus-Mussmaecher/rucola) - Terminal-based markdown note manager. [![Crate](https://img.shields.io/crates/v/rucola-notes.svg?logo=rust)](https://crates.io/crates/rucola-notes) [![Build Status](https://github.com/Linus-Mussmaecher/rucola/actions/workflows/continuous-testing.yml/badge.svg)](https://github.com/Linus-Mussmaecher/rucola/actions/workflows/continuous-testing.yml)
 * [Mobslide](https://github.com/thewh1teagle/mobslide) - Desktop application that turns your smartphone into presentation remote controller.
 * [mprocs](https://github.com/pvolok/mprocs) - TUI for running multiple processes


### PR DESCRIPTION
Adds [pixtuoid](https://github.com/IvanWng97/pixtuoid) to **Applications → Utilities** (alphabetical insert between \`guoxbin/dtool\` and \`Linus-Mussmaecher/rucola\`).

### What it is

A terminal pixel-art visualizer for AI coding agents — each running Claude Code session shows up as an animated half-block sprite in an ASCII coworking office. Multi-floor layout, per-tool monitor glow, A*-routed walking, weather effects, theme system.

### Eligibility check (per CONTRIBUTING.md)

- ⭐ **83 GitHub stars** (above the 50 threshold)
- 📦 [Published on crates.io](https://crates.io/crates/pixtuoid)
- 🔨 Actively maintained (latest release v0.4.1, shipped today)
- ✅ CI/tests: rustfmt, clippy (-D warnings), cargo-deny, workspace tests (200+), codecov, CodeQL
- 📜 MIT licensed

### Format

Following the CONTRIBUTING template: \`[ACCOUNT/REPO](URL) [[CRATE](crates.io URL)] - DESCRIPTION [CI badge]\`
![image](https://github.com/user-attachments/assets/ada94904-abb3-4d6d-b367-ef0dc1ddbb40)