### PR TITLE
Add Chipmunk Desktop Application to Observability Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,7 @@ See also [Games Made With Piston](https://github.com/PistonDevelopers/piston/wik
 ### Observability
 
 * [avito-tech/bioyino](https://github.com/avito-tech/bioyino) - A high-performance scalable StatsD compatible server.
+* [esrlabs/chipmunk](https://github.com/esrlabs/chipmunk) - Native egui desktop application for analyzing massive log files and streams. Features a WebAssembly plugin system and automotive formats support. [![Chipmunk CI](https://github.com/esrlabs/chipmunk/actions/workflows/lint_master.yml/badge.svg)](https://github.com/esrlabs/chipmunk/actions/workflows/lint_master.yml)
 * [MegaAntiCheat/client-backend](https://github.com/MegaAntiCheat/client-backend) - The client app for [MAC](https://github.com/MegaAntiCheat).
 * [openobserve](https://github.com/openobserve/openobserve) - 10x easier, 140x lower storage cost, high performance, petabyte scale - Elasticsearch/Splunk/Datadog alternative.
 * [OpenTelemetry](https://crates.io/crates/opentelemetry) - OpenTelemetry provides a single set of APIs, libraries, agents, and collector services to capture distributed traces and metrics from your application. You can analyze them using Prometheus, Jaeger, and other observability tools. [![GitHub Actions CI](https://github.com/open-telemetry/opentelemetry-rust/actions/workflows/ci.yml/badge.svg)](https://github.com/open-telemetry/opentelemetry-rust/actions/workflows/ci.yml)


### PR DESCRIPTION
- [x] - I have read the [CONTRIBUTING.md](CONTRIBUTING.md) and my pull request fulfills the criteria therein

[Chipmunk](https://github.com/esrlabs/chipmunk) is a log analyzer made for massive logs with support to multiple logs binary formats (related to automotive industry) and a plugin system using WebAssembly and the component model for our APIs.

This application has been in production for years and it was an electron app with backend written in Rust (Embedded node-model) to achieve the needed high performance.

Recently, we've rewritten the application frontend and application layers using `egui` to make the application %100 written in Rust. 

I've added it under **Observability** but I'm not sure if **Utilities** or **System Tools** might be a better fit 