### PR TITLE
Add run-llama/liteparse - fast PDF parsing library

### DIFF
--- a/README.md
+++ b/README.md
@@ -2053,6 +2053,7 @@ See also [Are we game yet?](https://arewegameyet.rs)
   * [oxc-project/oxc](https://github.com/oxc-project/oxc) [[oxc](https://crates.io/crates/oxc)] - High-performance JavaScript/TypeScript parser, transformer, minifier, and resolver written in Rust. Powers Rolldown, Nuxt, Nova, and more. [![Build Status](https://github.com/oxc-project/oxc/actions/workflows/ci.yml/badge.svg?event=push&branch=main)](https://github.com/oxc-project/oxc/actions/workflows/ci.yml)
   * [pest-parser/pest](https://github.com/pest-parser/pest) - The Elegant Parser
   * [ptal/oak](https://github.com/ptal/oak) - A typed PEG parser generator (compiler plugin)
+  * [run-llama/liteparse](https://github.com/run-llama/liteparse) [[liteparse](https://crates.io/crates/liteparse)] - Fast and light PDF parsing library with spatial text extraction, bounding boxes, flexible OCR (Tesseract/HTTP servers), and multi-language bindings (Rust, Node.js, Python, WASM). Built on PDFium with CLI tool `lit`. [![CI](https://github.com/run-llama/liteparse/actions/workflows/ci.yml/badge.svg)](https://github.com/run-llama/liteparse/actions/workflows/ci.yml)
   * [rust-bakery/nom](https://github.com/rust-bakery/nom) - parser combinator library
   * [s-panferov/queryst](https://github.com/s-panferov/queryst) - A query string parsing library inspired by [gs](https://github.com/ljharb/qs#readme)
   * [slimreaper35/dockerfile-parser-rs](https://github.com/slimreaper35/dockerfile-parser-rs) [[dockerfile-parser-rs](https://crates.io/crates/dockerfile-parser-rs)] - Dockerfile parsing library and CLI tool


### PR DESCRIPTION
- [ ] - I have read the [CONTRIBUTING.md](CONTRIBUTING.md) and my pull request fulfills the criteria therein

## Description
Add [liteparse](https://github.com/run-llama/liteparse) to the Libraries > Parsing section.

## About
LiteParse is a standalone OSS PDF parsing library written in Rust (70.3%) that provides:
-  Fast spatial text parsing using PDFium with precise bounding box extraction
-  Flexible OCR system: bundled Tesseract (zero setup) or plug in any HTTP OCR server (EasyOCR, PaddleOCR, custom)
-  Screenshot generation: high-quality PNG rendering for LLM agents and visual analysis
-  Multi-language bindings: Rust, Node.js/TypeScript (napi-rs), Python (PyO3), and Browser/WASM (wasm-bindgen)
-  Multi-platform support: Linux, macOS (Intel/ARM), Windows
-  CLI tool `lit`: unified interface across all installations (cargo, npm, pip)
-  Multi-format input: automatic conversion of DOCX, XLSX, PPTX, images to PDF via LibreOffice/ImageMagick
-  Agent-ready: installable as OpenClaw skill for AI agent workflows

## Criteria Check
- [x] GitHub stars: > 50
