### PR TITLE
Add quokka: iPhone inspection and cleanup CLI for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -660,6 +660,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 * [pop-os/system76-power](https://github.com/pop-os/system76-power/) - Linux power management daemon (DBus-interface) with CLI tool.
 * [pueue](https://github.com/nukesor/pueue) - Manage your long running shell commands. [![GitHub Actions Workflow](https://github.com/Nukesor/pueue/actions/workflows/test.yml/badge.svg)](https://github.com/nukesor/pueue/actions)
 * [qarmin/czkawka](https://github.com/qarmin/czkawka) - Multi-functional app to find duplicates, empty folders, similar images, etc. [![GitHub Actions Workflow](https://github.com/qarmin/czkawka/actions/workflows/pages/pages-build-deployment/badge.svg?branch=master)](https://github.com/qarmin/czkawka/actions)
+* [quokka](https://github.com/dutradotdev/quokka) — Terminal-native iPhone inspection and cleanup over USB for macOS. No jailbreak required.
 * [redox-os/ion](https://github.com/redox-os/ion) - Next-generation system shell
 * [sharkdp/bat](https://github.com/sharkdp/bat) - A cat(1) clone with wings. [![CICD](https://github.com/sharkdp/bat/actions/workflows/CICD.yml/badge.svg?branch=master)](https://github.com/sharkdp/bat/actions/workflows/CICD.yml)
 * [sharkdp/fd](https://github.com/sharkdp/fd) - A simple, fast and user-friendly alternative to find. [![CICD](https://github.com/sharkdp/fd/actions/workflows/CICD.yml/badge.svg)](https://github.com/sharkdp/fd/actions/workflows/CICD.yml)


### PR DESCRIPTION
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) and my pull request fulfills the criteria therein.

Adding quokka to the System tools section.

https://github.com/dutradotdev/quokka

macOS CLI for inspecting and managing iPhones over USB. Uses usbmuxd + Apple lockdown services. No jailbreak, no elevated privileges, no tunnel daemon.

What it does: inspect apps/storage/media, stream syslog, analyze large files, detect duplicate media, uninstall apps, reboot/shutdown device, TUI launcher.

Written in Rust. MIT license.