### PR TITLE
feat: add TWZRD Agent Intel MCP server to Blockchain section

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ If you want to contribute, please read [this](CONTRIBUTING.md).
 ### Blockchain
 
 * [Anchor](https://github.com/solana-foundation/anchor) - Anchor is the leading development framework for building secure Solana programs (smart contracts).
+* [TWZRD Agent Intel](https://intel.twzrd.xyz) - Solana-native x402 MCP server for AI agent trust scoring. Score any Solana wallet with 4 free preflight tools; pay-per-call `get_trust_receipt` returns a signed `twzrd.receipt.v5` via HTTP 402 + USDC micropayment. Zero-install: `claude mcp add twzrd-agent-intel --transport http https://intel.twzrd.xyz/mcp`
 * [artemis](https://github.com/paradigmxyz/artemis) - A simple, modular, and fast framework for writing MEV bots.
 * [Bitcoin Satoshi's Vision](https://github.com/brentongunning/rust-sv) [[sv](https://crates.io/crates/sv)] - A library for working with Bitcoin SV.
 * [cairo](https://github.com/starkware-libs/cairo) - Cairo is the first Turing-complete language for creating provable programs for general computation. This is also the native language of [StarkNet](https://www.starknet.io), a ZK-Rollup using STARK proofs ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/starkware-libs/cairo/CI?style=flat-square&logo=github)


### PR DESCRIPTION
## What

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the **Blockchain** section, after the existing Anchor entry.

## Why

TWZRD Agent Intel is a Solana-native MCP server built in Rust (Anchor programs on Solana mainnet). It provides AI agent trust scoring infrastructure:

- 4 free preflight tools: `resolve_agent`, `score_agent`, `preflight_check`, `verify_trust_receipt`
- Paid `get_trust_receipt` returns a signed `twzrd.receipt.v5` via HTTP 402 + on-chain USDC micropayment
- Implements the x402 payment protocol (HTTP 402 + Solana)
- Remote streamable HTTP transport — zero install for MCP clients

**Install (Claude Code CLI):**
```bash
claude mcp add twzrd-agent-intel --transport http https://intel.twzrd.xyz/mcp
```

**Config:**
```json
{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}
```

MCP Registry: `xyz.twzrd.intel/twzrd-agent-intel`