### PR TITLE
Add rustunnel to Tunnel section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1149,6 +1149,7 @@ See also [Rust Tools](https://rust-lang.org/tools/).
 ### Tunnel
 
 * [ekzhang/bore](https://github.com/ekzhang/bore) [[bore-cli](https://crates.io/crates/bore-cli)] - A simple TCP tunnel to expose local ports to a remote server, bypassing NAT firewalls [![Build status](https://img.shields.io/github/actions/workflow/status/ekzhang/bore/ci.yml)](https://github.com/ekzhang/bore/actions)
+* [joaoh82/rustunnel](https://github.com/joaoh82/rustunnel) - Self-hosted secure tunnel server. Exposes local HTTP/HTTPS/TCP/UDP services via TLS-encrypted WebSocket with yamux multiplexing; multi-region, Prometheus metrics, MCP server for AI agents.
 * [ngrok/ngrok-rust](https://github.com/ngrok/ngrok-rust) [[ngrok-rust](https://crates.io/crates/ngrok)] - ngrok is a developer tool that exposes your local app to the internet securely.
 * [rathole-org/rathole](https://github.com/rathole-org/rathole) - A secure, high-performance reverse proxy for NAT traversal with Noise Protocol/TLS encryption and hot-reload config support ![CI](https://img.shields.io/github/actions/workflow/status/rathole-org/rathole/rust.yml?branch=main)
 


### PR DESCRIPTION
Hi! I'm Joao (@joaoh82), author of rustunnel — a self-hosted, open-source secure tunnel server written in Rust (https://rustunnel.com).

Inserting alphabetically under **Development tools → Tunnel** (between `ekzhang/bore` and `ngrok/ngrok-rust`). It's a Rust-native, AGPL-3.0 project (Tokio/Axum/yamux, rustls for TLS), live at https://rustunnel.com with multi-region managed edges. Currently 631 stars on GitHub, well above the 50-star threshold in CONTRIBUTING.md.

- Source: https://github.com/joaoh82/rustunnel
- Docs: https://rustunnel.com/docs
- License: AGPL-3.0

The entry follows the CONTRIBUTING.md template (`[ACCOUNT/REPO](url) - DESCRIPTION`). No `crates.io` link since rustunnel ships as binaries / Docker images rather than a published crate. Happy to adjust the description, section placement, or formatting if anything's off.