### PR TITLE
Add concord to social networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,6 +589,8 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 
 ### Social networks
 
+* Discord
+  * [concord](https://github.com/chojs23/concord) - A feature-rich TUI client for Discord.
 * Mastodon
   * [Rustodon](https://github.com/rustodon/rustodon) - A Mastodon-compatible, ActivityPub-speaking server.
 * Telegram


### PR DESCRIPTION
- [x] - I have read the [CONTRIBUTING.md](CONTRIBUTING.md) and my pull request fulfills the criteria therein

Concord is tui client for discord written in rust. I also added Discord in `Social Networks` section.