### PR TITLE
Add Zizmor static analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1103,6 +1103,7 @@ See also [Rust Tools](https://rust-lang.org/tools/).
 * [RAPx](https://github.com/safer-rust/RAPx) - A platform that helps Rust programmers develop and use advanced static analysis tools beyond those provided by the rustc compiler.
 * [static_assertions](https://crates.io/crates/static_assertions) - Compile-time assertions to ensure that invariants are met
 * [verus-lang/verus](https://github.com/verus-lang/verus) - Verified Rust for low-level systems code
+* [zizmorcore/zizmor](https://github.com/zizmorcore/zizmor) [[zizmor](https://crates.io/crates/zizmor)] - Static analysis tool for GitHub Actions that finds security issues including template injection, credential leakage, excessive permissions, and impostor commits. [![CI](https://github.com/zizmorcore/zizmor/actions/workflows/ci.yml/badge.svg)](https://github.com/zizmorcore/zizmor/actions/workflows/ci.yml)
 
 ### Testing
 


### PR DESCRIPTION
- [ ] - I have read the [CONTRIBUTING.md](CONTRIBUTING.md) and my pull request fulfills the criteria therein

## Description
Add [zizmor](https://github.com/zizmorcore/zizmor) to the Development tools > Static analysis section.

## About
zizmor is a static analysis tool for GitHub Actions written in Rust (98.3%) that helps find common security issues in CI/CD workflows:

## Criteria Check
- [x] GitHub stars: > 50

## Why This Tool Matters
GitHub Actions security is critical for modern CI/CD pipelines. zizmor provides automated static analysis specifically designed for GitHub Actions workflows, filling an important gap in the Rust security tooling ecosystem.