### PR TITLE
Add HookSniff to Web section

### DIFF
--- a/README.md
+++ b/README.md
@@ -798,6 +798,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 * [agrinman/tunnelto](https://github.com/agrinman/tunnelto) [[tunnelto](https://crates.io/crates/tunnelto)] - Lets you expose your locally running web server via a public URL.
 * [cfal/tobaru](https://github.com/cfal/tobaru) - Port forwarder with allowlists, IP and TLS SNI/ALPN rule-based routing, iptables support, round-robin forwarding (load balancing), and hot reloading.
 * [hook0/hook0](https://github.com/hook0/hook0) - An open-source webhooks-as-a-service platform that makes it easy for SaaS developers to send webhooks
+* [servetarslan02/HookSniff](https://github.com/servetarslan02/HookSniff) - Open-source webhook delivery platform with automatic retries, HMAC-SHA256 signatures (Standard Webhooks), dead letter queue, FIFO ordering, and real-time analytics.
 * [importantimport/hatsu](https://github.com/importantimport/hatsu) - 🩵 Self-hosted and fully-automated ActivityPub bridge for static sites. [![release](https://github.com/importantimport/hatsu/actions/workflows/release.yml/badge.svg)](https://github.com/importantimport/hatsu/actions/workflows/release.yml)
 * [janreges/siteone-crawler](https://github.com/janreges/siteone-crawler) [[siteone-crawler](https://crates.io/crates/siteone-crawler)] - All-in-one
    website crawler, auditor, offline archiver, and AI-ready markdown exporter with CI/CD quality gating


### PR DESCRIPTION
Hi! I'd like to add **HookSniff** to the Web section.

**HookSniff** is an open-source webhook delivery platform built in Rust and Next.js.

**Key features:**
- Automatic retries with exponential backoff and jitter
- HMAC-SHA256 signatures (Standard Webhooks compliant)
- Dead letter queue for failed deliveries
- FIFO ordering with sequence numbers
- Smart routing (round-robin, failover, weighted)
- Real-time analytics dashboard with SSE streaming
- 11 official SDKs (Node.js, Python, Go, Rust, Java, etc.)

**Links:**
- GitHub: https://github.com/servetarslan02/HookSniff
- Live: https://hooksniff.vercel.app
- Docs: https://hooksniff.vercel.app/docs

Thanks for maintaining this awesome list! 🦀