### PR TITLE
Add Duckle to Applications > Workflow Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -834,6 +834,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 
 * [cowork-forge](https://github.com/sopaco/cowork-forge) - AI-native multi-agent platform that orchestrates specialized agents through a 7-stage pipeline to transform ideas into production-ready software. [![release](https://img.shields.io/github/actions/workflow/status/sopaco/cowork-forge/rust.yml?label=Build)](https://github.com/sopaco/cowork-forge/actions/workflows/release.yml)
 * [dali-benothmen/cronflow](https://github.com/dali-benothmen/cronflow) - Cronflow is a high-performance, developer-focused workflow automation library that lets you build and orchestrate complex, scalable automation workflows fully in code. [![release](https://github.com/dali-benothmen/cronflow/actions/workflows/release.yml/badge.svg)](https://github.com/dali-benothmen/cronflow/actions/workflows/release.yml)
+* [SouravRoy-ETL/duckle](https://github.com/SouravRoy-ETL/duckle) - Visual-first, open-source data studio (ETL/ELT) that runs entirely on DuckDB. Drag sources, transforms and sinks onto a canvas and it compiles to plain DuckDB SQL; 300+ connectors and a built-in MCP server. [![release](https://github.com/SouravRoy-ETL/duckle/actions/workflows/release.yml/badge.svg)](https://github.com/SouravRoy-ETL/duckle/actions/workflows/release.yml)
 
 ## Development tools
 


### PR DESCRIPTION
Adds [Duckle](https://github.com/SouravRoy-ETL/duckle) under **Applications > Workflow Automation** (alphabetically, after cronflow).

Duckle is a Rust desktop app (Tauri 2): a visual-first ETL/ELT studio that compiles a drag-and-drop pipeline canvas to plain DuckDB SQL. Open source (Apache-2.0 / MIT), ~377 stars, with a release build badge.