### PR TITLE
Add Darkly and Graphite.

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,8 @@ See also [Games Made With Piston](https://github.com/PistonDevelopers/piston/wik
 
 ### Image processing
 
+* [Darkly](https://github.com/darkly-art/darkly) - Entropic editor for digital artists and painters.
+* [Graphite](https://github.com/GraphiteEditor/Graphite) - Vector-based graphics editor.
 * [Imager](https://github.com/imager-io/imager) - Automated image optimization.
 * [oxipng](https://github.com/oxipng/oxipng) [[oxipng](https://crates.io/crates/oxipng)] - Multithreaded PNG optimizer written in Rust. [![Build Status](https://github.com/oxipng/oxipng/workflows/oxipng/badge.svg)](https://github.com/oxipng/oxipng/actions?query=branch%3Amaster) [![Version](https://img.shields.io/crates/v/oxipng.svg)](https://crates.io/crates/oxipng)
 * [visioncortex/vtracer](https://github.com/visioncortex/vtracer) [[vtracer](https://crates.io/crates/vtracer)] - A raster to vector graphics converter (jpg/png to svg).


### PR DESCRIPTION
[Graphite](https://github.com/GraphiteEditor/Graphite) is a vector-first editor written in Rust, with a node-based vector engine, great for graphic design and nondestructive workflows. [Darkly](https://github.com/darkly-art/darkly) is raster-first and geared instead toward digital painters, with a node-based brush engine and procreate-like stroke stabilization. Both run in the browser, and are written in Rust  + Svelte + Webassembly.

NOTE: I thought about adding a separate "art" or "digital art" category. But image processing is fine. Also shameless plug, I am the creator of Darkly.

- [x] - I have read the [CONTRIBUTING.md](CONTRIBUTING.md) and my pull request fulfills the criteria therein
