### PR TITLE
Add Slate - OLED-friendly Windows text editor (Rust + Tauri)

### DIFF
--- a/README.md
+++ b/README.md
@@ -707,8 +707,8 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 * [manyougz/velotype](https://github.com/manyougz/velotype) - A block-based native Markdown editor with WYSIWYG rendering and source editing modes, built on GPUI without a WebView shell.
 * [mathall/rim](https://github.com/mathall/rim) - Vim-like text editor.
 * [ox](https://github.com/curlpipe/ox) - An independent Rust text editor that runs in your terminal!
-* [SoloMD](https://github.com/zhitongblog/solomd) - A lightweight, cross-platform Markdown editor with live preview, built with Tauri 2.
 * [Slate](https://github.com/MiaAI-Lab/Slate) - A lightweight, OLED-friendly Windows markdown editor built with Tauri 2, Rust, and Svelte 5. Features live preview, multi-tab editing, zero telemetry, and a true-black OLED theme.
+* [SoloMD](https://github.com/zhitongblog/solomd) - A lightweight, cross-platform Markdown editor with live preview, built with Tauri 2.
 * [vamolessa/pepper](https://git.sr.ht/~lessa/pepper) [[pepper](https://crates.io/crates/pepper)] - An opinionated modal editor to simplify code editing from the terminal
 * [zed](https://github.com/zed-industries/zed) - A high-performance, multiplayer code editor from the creators of Atom and Tree-sitter.
 

--- a/README.md
+++ b/README.md
@@ -708,6 +708,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 * [mathall/rim](https://github.com/mathall/rim) - Vim-like text editor.
 * [ox](https://github.com/curlpipe/ox) - An independent Rust text editor that runs in your terminal!
 * [SoloMD](https://github.com/zhitongblog/solomd) - A lightweight, cross-platform Markdown editor with live preview, built with Tauri 2.
+* [Slate](https://github.com/MiaAI-Lab/Slate) - A lightweight, OLED-friendly Windows markdown editor built with Tauri 2, Rust, and Svelte 5. Features live preview, multi-tab editing, zero telemetry, and a true-black OLED theme.
 * [vamolessa/pepper](https://git.sr.ht/~lessa/pepper) [[pepper](https://crates.io/crates/pepper)] - An opinionated modal editor to simplify code editing from the terminal
 * [zed](https://github.com/zed-industries/zed) - A high-performance, multiplayer code editor from the creators of Atom and Tree-sitter.
 


### PR DESCRIPTION
Add [Slate](https://github.com/MiaAI-Lab/Slate) under Text editors.

Slate is a Windows text editor built with Rust + Tauri 2 + Svelte 5:
- OLED true-black theme (pure #000000)
- Local-first, zero telemetry, no cloud
- Live GFM preview with split view
- Multi-tab editing
- ~6MB installer