### PR TITLE
Add featherbar to System tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,6 +629,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 * [dust](https://github.com/bootandy/dust) - A more intuitive version of du
 * [erickochen/purple](https://github.com/erickochen/purple) [[purple-ssh](https://crates.io/crates/purple-ssh)] - Ratatui-powered SSH client with cloud sync, container management, file transfer, tunnels, snippets and password management [![CI](https://github.com/erickochen/purple/actions/workflows/ci.yml/badge.svg)](https://github.com/erickochen/purple/actions/workflows/ci.yml)
 * [eza-community/eza](https://github.com/eza-community/eza) - A replacement for 'ls'
+* [featherbar](https://github.com/nim444/featherbar) [[featherbar](https://crates.io/crates/featherbar)] - Featherweight macOS menu-bar system monitor for CPU, RAM, power, and temperature, with zero background threads and flat memory [![Crate](https://img.shields.io/crates/v/featherbar.svg?logo=rust)](https://crates.io/crates/featherbar)
 * [fish-shell/fish-shell](https://github.com/fish-shell/fish-shell) - The user-friendly command line shell
 * [fork](https://github.com/immortal/fork) - Library for creating a new process detached from the controlling terminal (daemon)
 * [fselect](https://crates.io/crates/fselect) - Find files with SQL-like queries


### PR DESCRIPTION
Adds [featherbar](https://github.com/nim444/featherbar) to the System tools section. A featherweight macOS menu-bar system monitor (CPU, RAM, power, temperature) written in Rust, published on crates.io. Inserted alphabetically.