### PR TITLE
Add rndc to Network programming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1991,6 +1991,8 @@ See also [Are we game yet?](https://arewegameyet.rs)
   * [bluez/bluer](https://github.com/bluez/bluer) [[bluer](https://crates.io/crates/bluer)] - Official BlueZ bindings. [![build badge](https://github.com/bluez/bluer/actions/workflows/rust.yml/badge.svg?branch=master)](https://github.com/bluez/bluer/actions/workflows/rust.yml)
 * CoAP
   * [Covertness/coap-rs](https://github.com/Covertness/coap-rs) - A [Constrained Application Protocol(CoAP)](https://datatracker.ietf.org/doc/html/rfc7252) library.
+* DNS
+  * [kweonminsung/bind9_rndc_rust](https://github.com/kweonminsung/bind9_rndc_rust) [[rndc](https://crates.io/crates/rndc)] - BIND9 RNDC protocol implementation for Rust [![CI](https://github.com/kweonminsung/bind9_rndc_rust/actions/workflows/ci.yml/badge.svg)](https://github.com/kweonminsung/bind9_rndc_rust/actions/workflows/ci.yml)
 * Docker
   * [fussybeaver/bollard](https://github.com/fussybeaver/bollard) - Docker daemon API
 * FTP


### PR DESCRIPTION
Adds [rndc](https://github.com/kweonminsung/bind9_rndc_rust), a Rust implementation of the BIND9 RNDC(Remote Name Daemon Control) protocol. The crate is available on [crates.io](https://crates.io/crates/rndc).

I added a new DNS subsection under Network programming because there does not appear to be an existing DNS category, and RNDC is a BIND9 DNS server control protocol.

The crate currently has 3,304 downloads on crates.io, which satisfies the 2,000-download criterion in CONTRIBUTING.md, and fits under the network programming section.

* [x] I have read the [CONTRIBUTING.md](https://github.com/rust-unofficial/awesome-rust/pull/CONTRIBUTING.md) and my pull request fulfills the criteria therein