### PR TITLE
Add solow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1436,6 +1436,7 @@ See also [About Rust’s Machine Learning Community](https://medium.com/@autumn_
   * [luqmana/rust-opencl](https://github.com/luqmana/rust-opencl) - [OpenCL](https://www.khronos.org/opencl/) bindings
 * Science
   * [Axect/Peroxide](https://github.com/Axect/Peroxide) - Rust numeric library containing linear algebra, numerical analysis, statistics and machine learning tools in pure rust
+  * [benovamurat/solow](https://github.com/benovamurat/solow) - A complete statistical-modeling, econometrics, and data-visualization toolkit — pure Rust, validated to near machine precision [![crates.io](https://img.shields.io/crates/v/solow.svg)](https://crates.io/crates/solow)
   * [cool-japan/scirs](https://github.com/cool-japan/scirs) - Production-Ready pure Rust scientific computing, includes linear algebra, optimization, statistics, neural networks and more. API inspired by Python's SciPy.
   * [cpmech/russell](https://github.com/cpmech/russell) - Rust Scientific Library for numerical mathematics, ordinary differential equations, special math functions, high-performance (sparse) linear algebra
   * [Nonanti/mathcore](https://github.com/Nonanti/mathcore) - Symbolic mathematics library with CAS capabilities. Supports differentiation, integration, equation solving, and arbitrary precision arithmetic [![crates.io](https://img.shields.io/crates/v/mathcore.svg)](https://crates.io/crates/mathcore)


### PR DESCRIPTION
Adds [**solow**](https://github.com/benovamurat/solow) under *Computation → Science*.

Solow is a from-scratch, fully-verified statistical-modeling, econometrics, and data-visualization toolkit for Rust — regression (OLS/WLS/GLS, robust, quantile), GLMs, discrete choice, time series & state space (Kalman/SARIMAX/VAR), survival, mixed effects, GEE, GAM, copulas, Bayesian VB, multivariate methods, a full statistical-test battery, and an SVG plotting backend.

- Pure Rust, no system LAPACK/BLAS, `#![forbid(unsafe_code)]`.
- Every estimator is cross-validated against an authoritative reference to ~1e-8, plus NIST StRD certified cases.
- Published on crates.io (`solow`), docs on docs.rs, user guide at https://benovamurat.github.io/solow.

The entry is placed alphabetically and follows the existing format.