### PR TITLE
Add bincode-next to binary encoders/decoders list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1698,6 +1698,7 @@ See also [About Rust’s Machine Learning Community](https://medium.com/@autumn_
   * [alex/rust-asn1](https://github.com/alex/rust-asn1) - ASN.1 (DER) serializer
 * Binary
   * [bincode](https://crates.io/crates/bincode) - A binary encoder/decoder
+  * [bincode-next](https://crates.io/crates/bincode-next) - A binary encoder/decoder, successor of the now unmaintained bincode
   * [jamesmunns/postcard](https://github.com/jamesmunns/postcard) [[postcard](https://crates.io/crates/postcard)] - Postcard is a #![no_std] focused serializer and deserializer for Serde.
   * [m4b/goblin](https://github.com/m4b/goblin) [[goblin](https://crates.io/crates/goblin)] - cross-platform, zero-copy, and endian-aware binary parsing
 * BSON


### PR DESCRIPTION
Added link to bincode-next as successor to bincode.

- [] - I have read the [CONTRIBUTING.md](CONTRIBUTING.md) and my pull request fulfills the criteria therein

Sorry for the interruption! We are developers of bincode-next.
We saw the criteria within the CONTRIBUTING.md, and found it a little bit of a special case here.
Bincode is a well known crate, and is important to many of our ecosystem. After it gone dark we surely need a successor and we do it.
Well as a basic crate in the foundation, star amounts do not go that high quickly so that we are just a little bit less then that criteria. But on the other hands, the crates.io download amount is well above 2000, now about 6000-8000 a day. And our dependents include gungraun, which is also the bench suite which the rust compiler uses; istring, which pdf-rs uses; and some other projects by Microsoft and other big firms.
We think it will be really quick to reach  the 50 star criteria as we are releasing a major new version. But in any sense, encoding/decoding is critical and we do not want to see any of our community members misled and start a new project on a unmaintained crate. So we are creating this pull request. 
But anyway, we respect the contributing requirements and if there are no special case bypass we would just wait for another few days or weeks.
Thanks for your patience anyway! 