### PR TITLE
Add agavra/tuicr - code review TUI with vim keybindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -849,6 +849,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 
 * [7df-lab/devo](https://github.com/7df-lab/devo) - A lightweight, model-neutral coding agent that runs as a single binary. Fast, token-efficient, and highly customizable. [![CI](https://github.com/7df-lab/devo/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/7df-lab/devo/actions/workflows/ci.yml)
 * [aaif-goose/goose](https://github.com/aaif-goose/goose) - An open-source, local AI agent that automates engineering tasks.
+* [agavra/tuicr](https://github.com/agavra/tuicr) [[tuicr](https://crates.io/crates/tuicr)] - Code review TUI with vim keybindings. Continuous diff viewer, PR-style comments, and export to GitHub/GitLab/clipboard. Supports git, jj, and mercurial. [![Crates.io](https://img.shields.io/crates/v/tuicr)](https://crates.io/crates/tuicr)
 * [armgabrielyan/deadbranch](https://github.com/armgabrielyan/deadbranch) [[deadbranch](https://crates.io/crates/deadbranch)] - Clean up stale git branches safely [![CI](https://github.com/armgabrielyan/deadbranch/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/armgabrielyan/deadbranch/actions/workflows/ci.yml)
 * [ATAC](https://github.com/Julien-cpsn/ATAC) - A feature-full TUI API client made in Rust. ATAC is free, open-source, offline and account-less.
 * [bacon](https://github.com/Canop/bacon) - background rust code checker, similar to cargo-watch


### PR DESCRIPTION
- [ ] - I have read the [CONTRIBUTING.md](CONTRIBUTING.md) and my pull request fulfills the criteria therein

## Description
Add [tuicr](https://github.com/agavra/tuicr) to the Development tools section.

## About
tuicr is a code review TUI written in Rust (98.2%) that provides:
-  **GitHub-style continuous diff**: Scroll through every changed file in one stream
-  **PR-style comments**: At line, range, file, and review level with classifications (issue, suggestion, note, praise)
-  **Multiple export targets**: Push to GitHub/GitLab, copy structured markdown to clipboard, or pipe to stdout
-  **Vim keybindings**: Full vim navigation model (j/k, visual mode, {N}G, Ctrl-d/u, etc.)
-  **Multi-VCS support**: Works with git, jj, and mercurial
-  **Review tracking**: At file or hunk granularity, persisted across sessions
-  **22 bundled themes**: Including catppuccin, gruvbox, nord, solarized, tokyo-night, and more
-  **Library API**: Rust library for tools that want to build on persisted review sessions

## Criteria Check
- [x] GitHub stars: > 50