### PR TITLE
Add bruits/satteri - high-performance Markdown and MDX processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1978,6 +1978,7 @@ See also [Are we game yet?](https://arewegameyet.rs)
 
 ### Markup language
 
+* [bruits/satteri](https://github.com/bruits/satteri) [[satteri](https://crates.io/crates/satteri)] - High-performance Markdown and MDX processing. Parses and compiles in Rust, runs plugins in JavaScript. Includes CommonMark parser with MDX extensions, MDAST/HAST tree operations, and NAPI bindings for JavaScript interop.
 * CommonMark
   * [pulldown-cmark/pulldown-cmark](https://github.com/pulldown-cmark/pulldown-cmark) - [CommonMark](https://commonmark.org/) parser
 * [insomnimus/tidier](https://github.com/insomnimus/tidier) [[tidier](https://crates.io/crates/tidier)] - A library to format HTML, XHTML and XML documents. [![build badge](https://github.com/insomnimus/tidier/actions/workflows/main.yml/badge.svg?branch=main)](https://github.com/insomnimus/tidier/actions)


### PR DESCRIPTION
- [ ] - I have read the [CONTRIBUTING.md](CONTRIBUTING.md) and my pull request fulfills the criteria therein

## Description
Add [Sätteri](https://github.com/bruits-org/satteri) to the Libraries > Markup language section.

## About
Sätteri is a high-performance Markdown and MDX processing library written in Rust (71.6%) that provides:
-  **Markdown/MDX processing**: Parses and compiles in Rust, runs plugins in JavaScript
- **CommonMark parser with MDX extensions**: Fork of pulldown-cmark with MDX support
-  **MDAST/HAST tree operations**: Full syntax tree manipulation with conversion between formats
-  **Plugin system**: Rust `Plugin` trait for Rust plugins with typed visitors and runner
- **JavaScript interop**: NAPI bindings exposing the Rust pipeline to JavaScript
-  **MDX compiler**: Fork of mdxjs-rs adapted for OXC (JavaScript/TypeScript compiler)
-  **Multi-crate architecture**: Modular design with `satteri`, `satteri-arena`, `satteri-ast`, `satteri-plugin-api`, `satteri-mdxjs-rs`, and `satteri-pulldown-cmark`
-  **Online playground**: Try it at https://satteri.bruits.org/playground

## Criteria Check
- [x] GitHub stars: > 50
