### PR TITLE
Add Dorion to social networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,6 +600,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 
 * Discord
   * [concord](https://github.com/chojs23/concord) - A feature-rich TUI client for Discord.
+  * [Dorion](https://github.com/SpikeHD/Dorion) - Tiny alternative Discord client with a smaller footprint, snappier startup, themes, plugins and more! ![build](https://img.shields.io/github/actions/workflow/status/SpikeHD/Dorion/build.yml)
 * Mastodon
   * [Rustodon](https://github.com/rustodon/rustodon) - A Mastodon-compatible, ActivityPub-speaking server.
 * Telegram


### PR DESCRIPTION
Dorion is an alternative Discord desktop client and it is built in Rust code with Tauri, supports themes, plugins and more. It allows to reduce significantly smaller than original Discord client.

The repository of Dorion is available on GitHub with source code: https://github.com/SpikeHD/Dorion
It has started since around 2.4K stars and 177K downloads reported on 29th June 2026.

Official website of SpikeHD's Dorion project: https://spikehd.dev/projects/dorion/

- [X] - I have read the [CONTRIBUTING.md](CONTRIBUTING.md) and my pull request fulfills the criteria therein

If you're happy and satisfied of project, then please merge the pull request. Thank you! :)

Kind regards,
Martin Eesmaa
