### PR TITLE
Add VelesDB (embeddable tri-engine vector + graph + columnar database)

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ If you want to contribute, please read [this](CONTRIBUTING.md).
 * [Turso](https://github.com/tursodatabase/turso) - Turso Database is an in-process SQL database, compatible with SQLite.
 * [USearch](https://github.com/unum-cloud/usearch) - Similarity Search Engine for Vectors and Strings [![crates.io](https://img.shields.io/crates/v/usearch.svg)](https://crates.io/crates/usearch)
 * [valentinus](https://github.com/kn0sys/valentinus) - Next generation vector database built with LMDB bindings [![Crates.io Version](https://img.shields.io/crates/v/valentinus)](https://crates.io/crates/valentinus)
+* [VelesDB](https://github.com/cyberlife-coder/VelesDB) [[velesdb-core](https://crates.io/crates/velesdb-core)] - Embeddable, local-first database whose tri-engine fuses vector search, a property graph, and a columnar store behind one query language (VelesQL), in a single binary. Ships an in-core agentic-memory SDK — semantic / episodic / procedural — with cross-session `why()` recall that traverses the graph to surface linked facts vector search alone misses.
 * [vorot93/libmdbx-rs](https://github.com/vorot93/libmdbx-rs) [[mdbx-sys](https://crates.io/crates/mdbx-sys)] - Bindings for MDBX, a "fast, compact, powerful, embedded, transactional key-value database, with permissive license". This is a fork of mozilla/lmdb-rs with patches to make it work with libmdbx.
 * [WooriDB](https://github.com/naomijub/wooridb) - General purpose time serial database inspired by Crux and Datomic.
 


### PR DESCRIPTION
Adds **VelesDB** to **Applications → Database** (placed alphabetically among the embeddable/vector entries).

VelesDB is an embeddable, local-first database in Rust whose **tri-engine fuses vector search + a property graph + a columnar store behind one query language (VelesQL)**, in a single binary. It ships an in-core **agentic-memory SDK** (semantic / episodic / procedural) with cross-session `why()` recall that traverses the graph to surface linked facts plain vector search misses.

**Eligibility (per CONTRIBUTING — stars > 50 OR downloads > 2000):**
- GitHub stars: **72**
- `velesdb-core` crates.io downloads: **2,827** total (~1,500 recent)

Both thresholds are met. Entry follows the template `[ACCOUNT/REPO](repo) [[CRATE](crates.io)] - DESCRIPTION`.
