### PR TITLE
Add gmacFTP to File manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,7 @@ See also [crates matching keyword 'emulator'](https://crates.io/keywords/emulato
 * [broot](https://github.com/Canop/broot) - A new way to see and navigate directory trees (get an overview of a directory, even a big one; find a directory then `cd` to it; never lose track of file hierarchy while you search; manipulate your files, ...), further reading [dystroy.org/broot](https://dystroy.org/broot/) [![Latest Version](https://img.shields.io/crates/v/broot.svg)](https://crates.io/crates/broot)
 * [elio-fm/elio](https://github.com/elio-fm/elio) [[elio](https://crates.io/crates/elio)] - Batteries-included terminal file manager with rich previews, bulk actions, and trash support.
 * [FileSSH](https://github.com/JayanAXHF/FileSSH) - A fast and easy to use TUI to manage files on a remote server, including quick SSH session creation, in-place file editing and more! ![crates.io](https://img.shields.io/crates/v/filessh)
+* [GMAC-pl/gmacFTP](https://github.com/GMAC-pl/gmacFTP) - A dual-pane FTP/FTPS/SFTP client for macOS, built in Rust with a Slint-based GPU-accelerated UI. No Electron, no webview.
 * [joshuto](https://github.com/kamiyaa/joshuto) - ranger-like terminal file manager
 * [moyangzhan/mango-finder](https://github.com/moyangzhan/mango-finder) - Search your files using nature language
 * [pikeru](https://github.com/dvhar/pikeru) - File picker for linux with good thumbnails and search


### PR DESCRIPTION
## What

Adds [gmacFTP](https://github.com/GMAC-pl/gmacFTP) to the **File manager** section.

## Why

gmacFTP is a free, open-source dual-pane FTP/FTPS/SFTP client for macOS, written entirely in Rust with a [Slint](https://slint.dev)-based GPU-accelerated UI. It is one of the few graphical FTP clients in the Rust ecosystem.

- **License:** GPL-3.0
- **Platform:** macOS 11+ (Apple Silicon)
- **Size:** ~7.5 MB DMG, signed and notarized
- **GUI:** Slint (FemtoVG renderer on wgpu/Metal) — no Electron, no Tauri, no webview
- **No telemetry, no accounts, no ads**

Placed alphabetically in the File manager section, between FileSSH and joshuto.