### PR TITLE
Add rusty-nano-frame

### DIFF
--- a/README.md
+++ b/README.md
@@ -797,6 +797,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 * [dertuxmalwieder/yaydl](https://github.com/dertuxmalwieder/yaydl) [[yaydl](https://crates.io/crates/yaydl)] - A simple video downloader
 * [gyroflow/gyroflow](https://github.com/gyroflow/gyroflow) - Video stabilization application using gyroscope data
 * [harlanc/xiu](https://github.com/harlanc/xiu) - A powerful and secure live server (rtmp/httpflv/hls/relay). [![crates.io](https://img.shields.io/crates/v/xiu.svg)](https://crates.io/crates/xiu)
+* [RuckieOfficial/rusty-nano-frame](https://github.com/RuckieOfficial/rusty-nano-frame) - Lightning-fast compressed GIF playback for ESP32 [![GitHub release](https://img.shields.io/github/v/release/RuckieOfficial/rusty-nano-frame)](https://github.com/RuckieOfficial/rusty-nano-frame/releases)
 * [vidmerger](https://github.com/TGotwig/vidmerger) - Merge video & audio files via CLI
 * [xiph/rav1e](https://github.com/xiph/rav1e) - The fastest and safest AV1 encoder.
 


### PR DESCRIPTION
Adds rusty-nano-frame, a lightning-fast compressed GIF playback for ESP32, to the Video applications section.