### PR TITLE
Add gitb - blazing-fast multi-repo git batch tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,6 +641,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 * [fork](https://github.com/immortal/fork) - Library for creating a new process detached from the controlling terminal (daemon)
 * [fselect](https://crates.io/crates/fselect) - Find files with SQL-like queries
 * [git-ai-project/git-ai](https://github.com/git-ai-project/git-ai) - A git extension that tracks AI-generated code in your repositories, linking lines to the agent, model, and transcripts.
+* [luolin1024/git-batch](https://github.com/luolin1024/git-batch) [[gitb](https://crates.io/crates/gitb)] - Blazing-fast multi-repo git batch tool with parallel execution [![CI](https://github.com/luolin1024/git-batch/actions/workflows/ci.yml/badge.svg)](https://github.com/luolin1024/git-batch/actions/workflows/ci.yml)
 * [gitbutlerapp/gitbutler](https://github.com/gitbutlerapp/gitbutler) - A modern Git-based version control interface with both a GUI and CLI built from the ground up for AI-powered workflows.
 * [gitui](https://github.com/gitui-org/gitui) - Blazing fast terminal client for git. [![build](https://github.com/gitui-org/gitui/actions/workflows/ci.yml/badge.svg)](https://github.com/gitui-org/gitui/actions)
 * [GQL](https://github.com/amrdeveloper/gql) - A SQL like query language to run on .git files.


### PR DESCRIPTION
Adds gitb, a Rust-powered multi-repo git batch CLI (3-4x faster than gita/mr). Cross-platform (macOS/Linux/Windows), zero-config, parallel execution via rayon, with shell completion and a reproducible benchmark script.

Repo: https://github.com/luolin1024/git-batch