### PR TITLE
Add CleitonForge — neutral quantum circuit benchmarking (Rust + PyO3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1447,6 +1447,7 @@ See also [About Rust’s Machine Learning Community](https://medium.com/@autumn_
   * [autumnai/collenchyma](https://github.com/autumnai/collenchyma) - An extensible, pluggable, backend-agnostic framework for parallel, high-performance computations on CUDA, OpenCL and common host CPU.
   * [luqmana/rust-opencl](https://github.com/luqmana/rust-opencl) - [OpenCL](https://www.khronos.org/opencl/) bindings
 * Science
+  * [cleitonaugusto/CleitonForge](https://github.com/cleitonaugusto/CleitonForge) - Neutral cross-backend benchmarking layer for quantum circuit simulators with Python bindings (PyO3). Discovered a silent Rz gate sign convention divergence that breaks QAOA fidelity to zero. Includes a convention normalization transpiler.
   * [Axect/Peroxide](https://github.com/Axect/Peroxide) - Rust numeric library containing linear algebra, numerical analysis, statistics and machine learning tools in pure rust
   * [cool-japan/scirs](https://github.com/cool-japan/scirs) - Production-Ready pure Rust scientific computing, includes linear algebra, optimization, statistics, neural networks and more. API inspired by Python's SciPy.
   * [cpmech/russell](https://github.com/cpmech/russell) - Rust Scientific Library for numerical mathematics, ordinary differential equations, special math functions, high-performance (sparse) linear algebra


### PR DESCRIPTION
## CleitonForge

**Link:** https://github.com/cleitonaugusto/CleitonForge  
**Category:** Science (Quantum computing)

Neutral cross-backend benchmarking layer for quantum circuit simulators, written in Rust with Python bindings via PyO3.

**What it does:**
- Routes identical circuits through multiple simulation backends via a canonical IR
- Compares statevector fidelity across backends
- Includes a convention normalization transpiler

**Notable finding:** Discovered that quantrs2-core uses the opposite Rz gate sign convention from IBM/Qiskit/OpenQASM 3, producing zero cross-backend fidelity on QAOA circuits. The divergence is invisible to Quantum Volume benchmarks. Published as a preprint: [DOI 10.5281/zenodo.21210972](https://doi.org/10.5281/zenodo.21210972).

**Crate:** Available on crates.io and PyPI (`pip install cleitonforge`)  
**License:** Apache 2.0