### PR TITLE
Add scope-rs (serial + RTT monitor TUI) to Development tools > Embedded

### DIFF
--- a/README.md
+++ b/README.md
@@ -988,6 +988,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
   * [japaric/rust-cross](https://github.com/japaric/rust-cross) - everything you need to know about cross compiling Rust programs
   * [japaric/xargo](https://github.com/japaric/xargo) - effortless cross compilation of Rust programs to custom bare-metal targets like ARM Cortex-M
 * Development Tools
+  * [matheuswhite/scope-rs](https://github.com/matheuswhite/scope-rs) [[scope-monitor](https://crates.io/crates/scope-monitor)] - Cross-platform serial-port & RTT monitor TUI with hex/@tag input macros, search, session recording, and Lua plugins. [![Build Status](https://github.com/matheuswhite/scope-rs/actions/workflows/build.yml/badge.svg)](https://github.com/matheuswhite/scope-rs/actions)
   * [probe-rs/probe-rs](https://github.com/probe-rs/probe-rs) [[probe-rs-tools](https://crates.io/crates/probe-rs-tools)] - Embedded debugging toolkit for flashing and debugging ARM and RISC-V microcontrollers.
   * [Vaishnav-Sabari-Girish/ComChan](https://github.com/Vaishnav-Sabari-Girish/ComChan) - A minimal serial monitor with plotter TUI.
 * Espressif


### PR DESCRIPTION
Adds [matheuswhite/scope-rs](https://github.com/matheuswhite/scope-rs) under **Development tools › Embedded › Development Tools** (inserted alphabetically, before `probe-rs`).

Scope is a cross-platform serial-monitor TUI (`ratatui`) that also talks to embedded targets over RTT via `probe-rs`. It offers colored, timestamped send/receive, hex and `@tag` input macros, search, session recording, auto-reconnect, and Lua plugins.

**Acceptance criteria:** `scope-monitor` has **~5,900 downloads on crates.io** (> 2000), meeting the popularity threshold. Follows the template `[ACCOUNT/REPO](url) [[CRATE](crate)] - DESCRIPTION` with a CI build badge, and is placed in alphabetical order.