### PR TITLE
Add minikv - distributed multi tenant KV

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ If you want to contribute, please read [this](CONTRIBUTING.md).
 * [valentinus](https://github.com/kn0sys/valentinus) - Next generation vector database built with LMDB bindings [![Crates.io Version](https://img.shields.io/crates/v/valentinus)](https://crates.io/crates/valentinus)
 * [VelesDB](https://github.com/cyberlife-coder/VelesDB) [[velesdb-core](https://crates.io/crates/velesdb-core)] - Embeddable, local-first database whose tri-engine fuses vector search, a property graph, and a columnar store behind one query language (VelesQL), in a single binary. Ships an in-core agentic-memory SDK — semantic / episodic / procedural — with cross-session `why()` recall that traverses the graph to surface linked facts vector search alone misses.
 * [vorot93/libmdbx-rs](https://github.com/vorot93/libmdbx-rs) [[mdbx-sys](https://crates.io/crates/mdbx-sys)] - Bindings for MDBX, a "fast, compact, powerful, embedded, transactional key-value database, with permissive license". This is a fork of mozilla/lmdb-rs with patches to make it work with libmdbx.
+* [whispem/minikv](https://github.com/whispem/minikv) - Distributed, multi-tenant key-value and object store with Raft consensus, WAL durability, time-series API, vector search, and S3-compatible endpoints. Production-oriented with Helm chart, Grafana dashboards, and Python SDK. [![Build Status](https://img.shields.io/badge/build-passing-brightgreen.svg)](.github/workflows/ci.yml)
 * [WooriDB](https://github.com/naomijub/wooridb) - General purpose time serial database inspired by Crux and Datomic.
 
 ### Embedded


### PR DESCRIPTION
- [ ] - I have read the [CONTRIBUTING.md](CONTRIBUTING.md) and my pull request fulfills the criteria therein

## Description
Add [minikv](https://github.com/whispem/minikv) to the Applications > Database section.

## About
minikv is a distributed, multi-tenant key-value and object store written in Rust that provides:
-  **Strong consistency**: Raft consensus for metadata and 2PC patterns for distributed writes
-  **Durability**: WAL and pluggable storage backends (RocksDB, Sled, in-memory)
-  **Multi-tenancy and security**: RBAC, API keys/JWT, AES-256-GCM encryption at rest
-  **Real-time and analytics**: Time-series API with aggregation/downsampling, vector similarity search
-  **Multiple APIs**: HTTP REST, S3-compatible endpoints, WebSocket/SSE watch, gRPC internal
-  **Production-ready**: Helm chart, Grafana dashboards, Prometheus alerts, Kubernetes operator
-  **Python SDK**: Notebook-first SDK with pandas/polars/pyarrow helpers for data science workflows
-  **Scalability**: 256 virtual shards, cross-DC replication primitives, multi-key operations

## Criteria Check
- [x] GitHub stars: > 50