### PR TITLE
Move cocoindex to MLOps, refocus description on fresh context for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,6 +473,7 @@ See also [Games Made With Piston](https://github.com/PistonDevelopers/piston/wik
 
 ### MLOps
 
+* [cocoindex](https://github.com/cocoindex-io/cocoindex) - ETL framework to build fresh context for AI agents, with incremental processing
 * [TensorZero](https://github.com/tensorzero/tensorzero) - data & learning flywheel for LLMs that unifies inference, observability, optimization, and experimentation ![TensorZero Build Status](https://img.shields.io/github/check-runs/tensorzero/tensorzero/main)
 
 ### Observability
@@ -1516,7 +1517,6 @@ See also [About Rust’s Machine Learning Community](https://medium.com/@autumn_
 
 * [amv-dev/yata](https://github.com/amv-dev/yata) - high performance technical analysis library [![Build Status](https://img.shields.io/github/workflow/status/amv-dev/yata/Rust?branch=master)](https://github.com/amv-dev/yata/actions?query=workflow%3ARust)
 * [bluss/ndarray](https://github.com/rust-ndarray/ndarray) - N-dimensional array with array views, multidimensional slicing, and efficient operations
-* [cocoindex](https://github.com/cocoindex-io/cocoindex) - ETL framework to build fresh index
 * [DataBora/elusion](https://github.com/DataBora/elusion) [[elusion](https://crates.io/crates/elusion)] - An end-to-end data engineering DataFrame library built on DataFusion, with connectors for Microsoft Fabric, Azure, SharePoint, FTP, Postgres, MySQL, and REST APIs
 * [datafusion](https://github.com/apache/datafusion) - DataFusion is a very fast, extensible query engine for building high-quality data-centric systems in Rust, using the Apache Arrow in-memory format.
 * [GoPlasmatic/datalogic-rs](https://github.com/GoPlasmatic/datalogic-rs) [[datalogic-rs](https://crates.io/crates/datalogic-rs)] - High-performance, type-safe JSONLogic evaluation engine in Rust, ideal for business rules and dynamic filtering.


### PR DESCRIPTION
Moves the existing [cocoindex](https://github.com/cocoindex-io/cocoindex) entry from **Data processing** to **MLOps**, placed alphabetically before TensorZero, and updates the description to reflect its current focus.

- **Before:** `ETL framework to build fresh index` (under Data processing)
- **After:** `ETL framework to build fresh context for AI agents, with incremental processing` (under MLOps)

**Why the move:** CocoIndex's primary use is building and continuously updating the context (embeddings, knowledge graphs) that AI agents and LLM apps reason over, using incremental processing to recompute only what changed. That fits the MLOps section better than generic Data processing.

**Popularity:** ~10.6k GitHub stars (well above the threshold); the project's core is written in Rust. Disclosure: I'm a maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)