### PR TITLE
Add smol-machines/smolvm to Virtualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -2247,6 +2247,7 @@ See also [Are we game yet?](https://arewegameyet.rs)
 * [chromium/chromiumos/platform/crosvm](https://chromium.googlesource.com/chromiumos/platform/crosvm/) - CrOSVM Enables Chrome OS to run Linux apps inside a fast, secure virtualized environment
 * [oxidecomputer/propolis](https://github.com/oxidecomputer/propolis) - Userspace program for illumos bhyve kernel modules
 * [saurvs/hypervisor-rs](https://github.com/saurvs/hypervisor-rs) - Hardware-accelerated virtualization on OS X
+* [smol-machines/smolvm](https://github.com/smol-machines/smolvm) - Portable microVM sandboxes on libkrun with copy-on-write forking of running VMs
 * [wasmi-labs/wasmi](https://github.com/wasmi-labs/wasmi) - A lightweight runtime for WebAssembly
 
 ### Web programming


### PR DESCRIPTION
smolvm — microVM manager in Rust on libkrun. Runs OCI images as VMs (Linux/macOS) and copy-on-write forks a running VM. 4.3k stars, so it's over the 50-star bar. Followed the template + alphabetical order; no crates.io release yet so I left off the [[CRATE]] link. Author here.