### PR TITLE
Add binlex to reverse engineering section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2137,6 +2137,7 @@ See also [Are we game yet?](https://arewegameyet.rs)
 
 ### Reverse engineering
 
+* [binlex](https://github.com/c3rb3ru5d3d53c/binlex) - Binary analysis and reverse engineering framework with function fingerprinting and similarity matching.
 * [idalib](https://github.com/idalib-rs/idalib) [[idalib](https://crates.io/crates/idalib)] - Rust bindings for the IDA SDK, enabling the development of standalone analysis tools using IDA v9.0’s idalib
 * [objdiff](https://github.com/encounter/objdiff) - A local diffing tool for decompilation projects
 


### PR DESCRIPTION
- [x] - I have read the [CONTRIBUTING.md](CONTRIBUTING.md) and my pull request fulfills the criteria therein
https://github.com/AliPayandehDev
## Summary

- Add Binlex to the Reverse engineering section.
- Binlex is an open-source binary analysis and reverse engineering framework focused on function fingerprinting, similarity matching, and malware analysis.