### PR TITLE
Add aisk/rust-fire to Command-line argument parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1349,6 +1349,7 @@ See also [About Rust’s Machine Learning Community](https://medium.com/@autumn_
 ### Command-line
 
 * Argument parsing
+  * [aisk/rust-fire](https://github.com/aisk/rust-fire) [[fire](https://crates.io/crates/fire)] - Turn your function(s) to a command line app with one line of code [![CI](https://github.com/aisk/rust-fire/actions/workflows/ci.yml/badge.svg)](https://github.com/aisk/rust-fire/actions/workflows/ci.yml)
   * [clap-rs](https://github.com/clap-rs/clap) [[clap](https://crates.io/crates/clap)] - A simple to use, full featured command-line argument parser
   * [cliparser](https://crates.io/crates/cliparser) - Simple command line parser. [![build badge](https://github.com/sagiegurari/cliparser/actions/workflows/ci.yml/badge.svg)](https://github.com/sagiegurari/cliparser/actions)
   * [docopt/docopt.rs](https://github.com/docopt/docopt.rs) [[docopt](https://crates.io/crates/docopt)] - Implementation of DocOpt


### PR DESCRIPTION
- [x] - I have read the [CONTRIBUTING.md](CONTRIBUTING.md) and my pull request fulfills the criteria therein

Adding my own crate [fire](https://crates.io/crates/fire) ([aisk/rust-fire](https://github.com/aisk/rust-fire)) — a proc-macro that turns a function, or an inline module of functions, into a CLI app via a single `#[fire::main]` attribute. Python-fire vibes, but for Rust. ~5.6k downloads on crates.io.

Dropped it at the top of Argument parsing so the list stays alphabetical.