### PR TITLE
Add pg-walstream to PostgreSQL section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1654,6 +1654,7 @@ See also [About Rust’s Machine Learning Community](https://medium.com/@autumn_
     * [kubo/rust-oracle](https://github.com/kubo/rust-oracle) [[oracle](https://crates.io/crates/oracle)] - Oracle driver [![build badge](https://github.com/kubo/rust-oracle/actions/workflows/run-tests.yml/badge.svg?branch=master)](https://github.com/kubo/rust-oracle/actions/workflows/run-tests.yml)
   * PostgreSql [[postgres](https://crates.io/keywords/postgres), [postgresql](https://crates.io/keywords/postgresql)]
     * [c410-f3r/wtx](https://github.com/c410-f3r/wtx) - Fast implementation with a low set of external dependencies.
+    * [isdaniel/pg-walstream](https://github.com/isdaniel/pg-walstream) - High-performance async CDC (Change Data Capture) library for PostgreSQL logical and physical replication streaming. [![Crates.io Version](https://img.shields.io/crates/v/pg_walstream)](https://crates.io/crates/pg_walstream)
     * [rust-postgres](https://github.com/rust-postgres/rust-postgres) [[postgres](https://crates.io/crates/postgres)] - A native [PostgreSQL](https://www.postgresql.org/) client
   * Sqlite [[sqlite](https://crates.io/keywords/sqlite)]
     * [rusqlite](https://github.com/rusqlite/rusqlite) - [Sqlite3](https://sqlite.org/index.html) bindings


### PR DESCRIPTION
- [x] - I have read the [CONTRIBUTING.md](CONTRIBUTING.md) and my pull request fulfills the criteria therein

Adds isdaniel/pg-walstream to Database → PostgreSql. It's a high-performance async CDC / logical + physical replication library a category not yet represented in that subsection (currently only wtx and rust-postgres).

Popularity metric: ~31,000 downloads on crates.io (well above the 2,000-download bar in CONTRIBUTING.md). Entry follows the template and alphabetical ordering.

https://github.com/isdaniel/pg-walstream
