### PR TITLE
Add bigduu/Bamboo-agent (bamboo-agent crate)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1242,6 +1242,7 @@ See also [About Rust’s Machine Learning Community](https://medium.com/@autumn_
 * [0xplaygrounds/rig](https://github.com/0xplaygrounds/rig) - Library for creating agents and modular, scalable LLM-powered applications
 * [64bit/async-openai](https://github.com/64bit/async-openai) [[async-openai](https://crates.io/crates/async-openai)] - Ergonomic Rust bindings for OpenAI API based on OpenAPI spec.
 * [awakenworks/awaken](https://github.com/awakenworks/awaken) [[awaken](https://crates.io/crates/awaken)] - AI agent runtime for Rust — type-safe state, multi-protocol serving, plugin extensibility.
+* [bigduu/Bamboo-agent](https://github.com/bigduu/Bamboo-agent) [[bamboo-agent](https://crates.io/crates/bamboo-agent)] - Local-first AI agent harness & runtime — persistent memory, built-in tools, skills, MCP, sub-agents, workflows and schedules behind one HTTP + WebSocket API. Embeddable as a crate or runnable as a server.
 * [liquidos-ai/AutoAgents](https://github.com/liquidos-ai/AutoAgents) [[AutoAgents](https://crates.io/crates/autoagents)] - Multi Agent Framework for building AI agents with native edge support.
 * [openai/codex](https://github.com/openai/codex) - Codex CLI is a coding agent from OpenAI that runs locally.
 * [openai/harmony](https://github.com/openai/harmony) [[openai-harmony](https://crates.io/crates/openai-harmony/0.0.3)] - Renderer for the harmony response format to be used with gpt-oss.


### PR DESCRIPTION
Adds **[bigduu/Bamboo-agent](https://github.com/bigduu/Bamboo-agent)** [[bamboo-agent](https://crates.io/crates/bamboo-agent)] under Artificial Intelligence → OpenAI (where the other LLM agent runtimes live), in alphabetical order.

Bamboo is a local-first AI agent harness & runtime: persistent memory, built-in tools, skills, MCP, sub-agents, workflows and schedules behind one HTTP + WebSocket API; embeddable as a crate or runnable as a server.

Popularity metric per CONTRIBUTING: **2,382 downloads on crates.io** (1,396 in the last 90 days), which clears the `downloads > 2000` bar.

https://claude.ai/code/session_01UL4szV36SJjZbt2XnUCMdm
