### PR TITLE
Add Tura-AI/tura

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ If you want to contribute, please read [this](CONTRIBUTING.md).
 * [temps](https://github.com/gotempsh/temps) - A self-hosted PaaS that replaces Vercel, analytics, error tracking, and uptime monitoring with a single Rust binary
 * [tiny](https://github.com/osa1/tiny) - A terminal IRC client
 * [topjohnwu/Magisk](https://github.com/topjohnwu/Magisk) - A suite of open source tools for customizing Android, providing root access, boot image manipulation, and systemless modifications
+* [Tura-AI/tura](https://github.com/Tura-AI/tura) - A local coding agent for terminal, desktop GUI, and command-line workflows, with persistent task state and evidence-backed verification. [![CI](https://github.com/Tura-AI/tura/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/Tura-AI/tura/actions/workflows/ci.yml)
 * [Typst](https://github.com/typst/typst) - A markup-based typesetting system [![crates.io](https://img.shields.io/crates/v/typst.svg)](https://crates.io/crates/typst)
 * [UpVPN](https://github.com/upvpn/upvpn-app) - WireGuard VPN client for macOS, Linux, and Windows built on Tauri.
 * [vortix](https://github.com/Harry-kp/vortix) - Terminal UI for WireGuard and OpenVPN with real-time telemetry, leak detection, and kill switch


### PR DESCRIPTION
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) and my pull request fulfills the criteria therein.

## Summary

Add Tura to the Applications section in alphabetical order. Tura is a local coding agent implemented primarily in Rust, with terminal, desktop GUI, and command-line workflows.

## Eligibility and verification

- Tura has 67 GitHub stars at submission time, above the list's `> 50` requirement.
- GitHub language statistics report 59.67% Rust, above the repository checker's 1% minimum.
- The repository, CI workflow page, and branch-qualified CI badge return HTTP 200.
- `cargo fmt -- --check`: passed.
- `cargo build`: passed.
- `git diff --check`: passed.
- The full-list network checker exceeded a five-minute local limit while checking the existing catalog; no Tura-specific criterion failed.
- Local Markdown lint reports only the pre-existing upstream MD039 issue at README line 282; the added Tura line has no lint finding.

I am affiliated with the Tura project. I used AI assistance to read the repository rules, verify eligibility and duplicate state, draft this one-line entry, and run checks; I reviewed the final change.