### PR TITLE
Add YAKC to Applications/Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -797,6 +797,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 * [Water-Run/treepp](https://github.com/Water-Run/treepp) - A Rust-based native Windows `tree` replacement with diff-level input/output compatibility on successful runs, many more features including essential exclusions and `.gitignore` support, and several-times faster performance.
 * [wrestic](https://github.com/alvaro17f/wrestic) - A wrapper around restic.
 * [wthrr](https://github.com/ttytm/wthrr-the-weathercrab) - Weather companion for the terminal. [![crates.io](https://img.shields.io/crates/v/wthrr?logo=rust)](https://crates.io/crates/wthrr)
+* [YAKC](https://github.com/iammodev/YAKC) - Cross-platform keystroke & mouse-click visualizer for screencasts, streaming, and presentations. Works on Windows, macOS, and Linux (X11 & Wayland). [![CI](https://github.com/iammodev/YAKC/actions/workflows/ci.yml/badge.svg)](https://github.com/iammodev/YAKC/actions/workflows/ci.yml)
 * [YueMiyuki/Risuko](https://github.com/YueMiyuki/Risuko) - A full-featured download manager. [![Release-Badge](https://github.com/YueMiyuki/Risuko/actions/workflows/release.yml/badge.svg)](https://github.com/YueMiyuki/Risuko/actions/workflows/release.yml)
 
 ### Video


### PR DESCRIPTION
Adds **YAKC (Yet Another Key Caster)** to Applications → Utilities.

YAKC is a Rust + [Tauri](https://tauri.app) **keystroke & mouse-click visualizer** — it shows on-screen popups of the keys and clicks you make, for screencasts, streaming and presentations. It runs on **Windows, macOS and Linux (X11 and Wayland)** and shows any keyboard language automatically.

- Repo: https://github.com/iammodev/YAKC
- Releases (installers for all platforms): https://github.com/iammodev/YAKC/releases/latest

Entry is alphabetical and follows the existing single-line format with a CI badge.