### PR TITLE
Add vietanhdev/bulwark to Security tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -610,6 +610,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 * [sherlock](https://github.com/jonaylor89/sherlock-rs) [[sherlock](https://crates.io/crates/sherlock)] - Hunt down social media accounts by username across social networks [![status](https://github.com/jonaylor89/sherlock-rs/actions/workflows/rust.yml/badge.svg)](https://github.com/jonaylor89/sherlock-rs/actions/workflows/rust.yml)
 * [ssh-vault](https://github.com/ssh-vault/ssh-vault) - A simple tool to manage secrets using ssh keys for encryption and decryption.
 * [SystemVll/TAuth](https://github.com/SystemVll/TAuth) - An easy and user friendly 2FA & Credentials manager, for your PC.
+* [vietanhdev/bulwark](https://github.com/vietanhdev/bulwark) - Host security scanner for Linux desktops and servers with a CLI and a native GUI, checking SSH, kernel, cron and filesystem permissions against a declarative rule pack, with ClamAV integration and file-integrity monitoring [![CI](https://github.com/vietanhdev/bulwark/actions/workflows/ci.yml/badge.svg)](https://github.com/vietanhdev/bulwark/actions/workflows/ci.yml)
 
 ### Social networks
 


### PR DESCRIPTION
Adding Bulwark, a host security scanner for Linux. I'm the author.

**On the popularity bar, up front:** I don't meet it yet. The repo is about a week old and has 0 stars, and the CLI isn't on crates.io, so neither of the two objective thresholds is cleared. I'm opening this under the "equivalent level of other popularity metrics" clause, but I'd rather state the numbers than bury them — if the answer is "come back at 50 stars", that's completely fair and I'll resubmit then.

What I have instead of stars is distribution: it's packaged in an Ubuntu PPA (`ppa:vietanhng/bulwark`), on the AUR as `bulwarkctl`, and in a Fedora COPR, with `.deb`/`.rpm`/AppImage builds on each release. Whether that counts as equivalent is your call, not mine.

On the tool itself: it checks a machine's real configuration — SSH, sudo, kernel sysctls, cron, systemd units, filesystem permissions — against a pack of declarative YAML rules, so adding a check doesn't mean writing Rust. It integrates ClamAV for signature scanning and does file-integrity monitoring. The workspace is a `bulwark-core` library crate with no UI and no network calls, plus two thin front-doors: a clap CLI and a Tauri v2 desktop app that share the same engine, rule pack and SQLite store.

Apache-2.0. Alphabetical placement in Security tools, CI badge included per CONTRIBUTING.