### PR TITLE
Add rsigma to Security tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -611,6 +611,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 * [sherlock](https://github.com/jonaylor89/sherlock-rs) [[sherlock](https://crates.io/crates/sherlock)] - Hunt down social media accounts by username across social networks [![status](https://github.com/jonaylor89/sherlock-rs/actions/workflows/rust.yml/badge.svg)](https://github.com/jonaylor89/sherlock-rs/actions/workflows/rust.yml)
 * [ssh-vault](https://github.com/ssh-vault/ssh-vault) - A simple tool to manage secrets using ssh keys for encryption and decryption.
 * [SystemVll/TAuth](https://github.com/SystemVll/TAuth) - An easy and user friendly 2FA & Credentials manager, for your PC.
+* [timescale/rsigma](https://github.com/timescale/rsigma) [[rsigma](https://crates.io/crates/rsigma)] - A complete detection engineering toolkit for the Sigma detection standard, with a parser, evaluation engine, rule conversion, streaming runtime, linter, CLI, MCP, and LSP [![CI](https://github.com/timescale/rsigma/actions/workflows/ci.yml/badge.svg)](https://github.com/timescale/rsigma/actions/workflows/ci.yml)
 
 ### Social networks
 


### PR DESCRIPTION
Adds [rsigma](https://github.com/timescale/rsigma) to the Security tools section.

rsigma is a detection engineering toolkit for the [Sigma](https://sigmahq.io/) detection standard, with a parser, evaluation engine, rule conversion, streaming runtime, linter, CLI, MCP, and LSP.

Guidelines checklist:

- Popularity: 111 GitHub stars (> 50 required)
- Template: `[ACCOUNT/REPO](url) [[CRATE](url)] - DESCRIPTION` plus CI build badge
- Alphabetical ordering preserved within the Security tools list