### PR TITLE
Add Edky to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -760,6 +760,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 ### Utilities
 
 * [1History](https://github.com/localfirstapp/1History) - Command line interface to backup Firefox/Chrome/Safari history to one SQLite file [![Build Status](https://github.com/localfirstapp/1History/actions/workflows/CI.yml/badge.svg)](https://github.com/localfirstapp/1History/actions/workflows/CI.yml)
+* [artob/edky](https://github.com/artob/edky) [[edky](https://crates.io/crates/edky)] - A command-line utility to convert Ed25519 public keys between various encoding formats (Base58, Base64, IPFS, iroh, libp2p, OpenSSH, etc). [![Build Status](https://github.com/artob/edky/actions/workflows/rust.yaml/badge.svg)](https://github.com/artob/edky/blob/master/.github/workflows/rust.yaml)
 * [bloznelis/kbt](https://github.com/bloznelis/kbt) [[kbt](https://crates.io/crates/kbt)] - A simple TUI tool for keyboard testing.
 * [brycx/checkpwn](https://github.com/brycx/checkpwn) - A Have I Been Pwned (HIBP) command-line utility tool that lets you easily check for compromised accounts and passwords.
 * [cartesiancs/vessel](https://github.com/cartesiancs/vessel) - C2 (Command & Control) software for orchestrating physical devices.


### PR DESCRIPTION
**[Edky] converts Ed25519 public keys between various encoding formats, such as Base16, Base58, Base64, etc.**

```shellsession
$ cargo binstall -y edky

$ edky convert -f hex -t base64url d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a
11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo

$ edky convert -f hex -t openssh d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a
ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINdamAGCsQq31Uv+08lkBzoO4XLz2qYjJa8CGmj3B1Ea
```

<img width="100%" alt="Showcase of edky convert" src="https://github.com/artob/edky/raw/master/rust/etc/asciinema/convert.gif"/>

[Edky]: https://github.com/artob/edky

## Formalities

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) and my pull request fulfills the criteria therein: it currently has [~6.6K downloads on Crates.io](https://crates.io/crates/edky), which is significantly more than the needed acceptance threshold of 2K
