### PR TITLE
Add Reado to Applications → Text editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -729,6 +729,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 * [manyougz/velotype](https://github.com/manyougz/velotype) - A block-based native Markdown editor with WYSIWYG rendering and source editing modes, built on GPUI without a WebView shell.
 * [mathall/rim](https://github.com/mathall/rim) - Vim-like text editor.
 * [ox](https://github.com/curlpipe/ox) - An independent Rust text editor that runs in your terminal!
+* [Reado](https://github.com/WatermelonBros/reado) - A read-first, cross-platform code IDE built with Tauri; read and annotate code with durable, git-tracked comments that an external AI agent (Claude Code, Codex, …) resolves.
 * [SoloMD](https://github.com/zhitongblog/solomd) - A lightweight, cross-platform Markdown editor with live preview, built with Tauri 2.
 * [vamolessa/pepper](https://git.sr.ht/~lessa/pepper) [[pepper](https://crates.io/crates/pepper)] - An opinionated modal editor to simplify code editing from the terminal
 * [zed](https://github.com/zed-industries/zed) - A high-performance, multiplayer code editor from the creators of Atom and Tree-sitter.


### PR DESCRIPTION
Adds **Reado**, an open-source read-first code IDE written in Rust (Tauri + React, MIT), under Applications → Text editors.

You read and annotate code with durable, git-tracked comments; an external AI agent (Claude Code, Codex, …) resolves the tasks. No embedded LLM.

- Repo: https://github.com/WatermelonBros/reado
- Placed alphabetically (between `ox` and `SoloMD`), matching the section's format.
- Sits alongside the other Rust/Tauri editors already listed (Lapce, Zed, Ferrite, Inkwell, SoloMD).