### PR TITLE
Add Anycode to Text editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -718,6 +718,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 ### Text editors
 
 * [amp](https://amp.rs) - Inspired by Vi/Vim.
+* [Anycode](https://github.com/anycode-ade/anycode) - Web-based IDE with Rust backend (Axum, Tokio) and React frontend supporting code editing, LSP, and AI agents.
 * [Ferrite](https://github.com/OlaProeis/Ferrite) - A cross-platform markdown editor built with egui, featuring live preview, syntax highlighting, and mermaid diagrams.
 * [Fresh](https://github.com/sinelaw/fresh) - An easy-to-use, powerful and fast terminal text editor & IDE, with TypeScript plugin support.
 * [gchp/iota](https://github.com/gchp/iota) - A simple text editor


### PR DESCRIPTION
Adds Anycode (web-based IDE with Rust backend and React frontend) to the Text editors section.