### PR TITLE
Add zerx-lab/FluxDown to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -809,6 +809,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 * [wthrr](https://github.com/ttytm/wthrr-the-weathercrab) - Weather companion for the terminal. [![crates.io](https://img.shields.io/crates/v/wthrr?logo=rust)](https://crates.io/crates/wthrr)
 * [YAKC](https://github.com/iammodev/YAKC) - Cross-platform keystroke & mouse-click visualizer for screencasts, streaming, and presentations. Works on Windows, macOS, and Linux (X11 & Wayland). [![CI](https://github.com/iammodev/YAKC/actions/workflows/ci.yml/badge.svg)](https://github.com/iammodev/YAKC/actions/workflows/ci.yml)
 * [YueMiyuki/Risuko](https://github.com/YueMiyuki/Risuko) - A full-featured download manager. [![Release-Badge](https://github.com/YueMiyuki/Risuko/actions/workflows/release.yml/badge.svg)](https://github.com/YueMiyuki/Risuko/actions/workflows/release.yml)
+* [zerx-lab/FluxDown](https://github.com/zerx-lab/FluxDown) - A multi-protocol download manager with a Rust/Tokio engine, supporting HTTP/FTP, BitTorrent, eD2K, HLS and DASH, with IDM-style dynamic segmentation, browser extensions and an aria2-compatible JSON-RPC endpoint.
 
 ### Video
 


### PR DESCRIPTION
Adds [FluxDown](https://github.com/zerx-lab/FluxDown) to Applications -> Utilities, alphabetically at the end of the section.

FluxDown is a cross-platform download manager. The engine is Rust + Tokio (HTTP/FTP, BitTorrent, eD2K, HLS, DASH, dynamic segment splitting, SQLite-backed resume) and it ships an aria2-compatible JSON-RPC endpoint so existing aria2 clients can drive it. Website: https://fluxdown.zerx.dev

Criteria check:
- 1000+ stars on GitHub, well above the 50 star threshold.
- Not published on crates.io, so the `[[CRATE]]` part is omitted per CONTRIBUTING.
- AGPL-3.0.

- [x] - I have read the [CONTRIBUTING.md](CONTRIBUTING.md) and my pull request fulfills the criteria therein