### PR TITLE
Add NON-OS/nonos-micro-kernel to Operating systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,6 +504,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 * [DragonOS-Community/DragonOS](https://github.com/DragonOS-Community/DragonOS) - An operating system with a self-developed kernel from scratch and Linux compatibility.
 * [hexagonal-sun/moss-kernel](https://github.com/hexagonal-sun/moss-kernel) - A Unix-like, Linux-compatible kernel written in Rust and Aarch64 assembly.
 * [koibtw/highlightos](https://github.com/koibtw/highlightos) - x86_64 OS kernel written in Rust & Assembly.
+* [NON-OS/nonos-micro-kernel](https://github.com/NON-OS/nonos-micro-kernel) - A capability-based, RAM-resident microkernel where every program is a signed capsule that must prove itself before the kernel will run it, and drivers run in userspace.
 * [redox-os/redox](https://gitlab.redox-os.org/redox-os/redox) - A Unix-like general-purpose microkernel-based operating system with a focus on security, stability, performance, correctness, simplicity and pragmatism that aims to be a complete alternative for Linux and BSD.
 * [thepowersgang/rust_os](https://github.com/thepowersgang/rust_os) - An OS kernel written in rust. Non POSIX
 * [theseus-os/Theseus](https://github.com/theseus-os/Theseus) - A safe-language, single address space and single privilege level OS written from scratch - [![build badge](https://img.shields.io/github/workflow/status/theseus-os/Theseus/Documentation?label=docs%20build)](https://www.theseus-os.com/Theseus/book/index.html)


### PR DESCRIPTION
Adds NØNOS to the Operating systems section.

It is a capability-based microkernel written in Rust, `no_std` on a custom x86_64 target. Every program runs as a signed capsule that carries a proof of what it is, which the kernel verifies before it will start it, and no capsule holds authority it was not explicitly granted. Drivers are not in the kernel either: they run in ring 3 and reach hardware through a capability broker, including a from-scratch Realtek Wi-Fi driver that completes the WPA2 handshake and carries real traffic on a physical laptop.

The first public beta boots in QEMU, VirtualBox and on real x86_64 hardware.

Currently at 83 stars, which meets the >50 threshold. Not published on crates.io, so the crate link is omitted per the template. Placed alphabetically between koibtw and redox-os.

AGPL-3.0. https://nonos.software
