### PR TITLE
Add GCWing/BitFun to Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ If you want to contribute, please read [this](CONTRIBUTING.md).
 * [fcsonline/drill](https://github.com/fcsonline/drill) - A HTTP load testing application inspired by Ansible syntax
 * [fend](https://github.com/printfn/fend) - Arbitrary-precision unit-aware calculator [![build](https://github.com/printfn/fend/workflows/build/badge.svg)](https://github.com/printfn/fend/actions/workflows/actions.yml)
 * [Fractalide](https://github.com/fractalide/fractalide) - Simple microservices
+* [GCWing/BitFun](https://github.com/GCWing/BitFun) - A cross-platform desktop AI agent with a Rust runtime that works in real repositories and can drive the browser, terminal, and desktop applications
 * [giga-grabber](https://github.com/chanderlud/giga-grabber) - A very fast and relatively stable Mega downloader [![build](https://github.com/chanderlud/giga-grabber/actions/workflows/release.yml/badge.svg)](https://github.com/chanderlud/giga-grabber/actions/workflows/release.yml)
 * [glzr-io/glazewm](https://github.com/glzr-io/glazewm) - A tiling window manager for Windows inspired by i3wm, with YAML config, multi-monitor support, and keyboard-driven commands
 * [google/mdbook-i18n-helpers](https://github.com/google/mdbook-i18n-helpers) [[mdbook-i18n-helpers](https://crates.io/crates/mdbook-i18n-helpers)] - Internationalization and rendering extensions for mdbook.


### PR DESCRIPTION
Adds [GCWing/BitFun](https://github.com/GCWing/BitFun) to `## Applications`.

BitFun is a cross-platform desktop AI agent. Its Agent Runtime is written in Rust (27.6 MB of Rust in the repo, `tauri 2.11` + Tokio), and it ships signed installers for macOS, Windows, and Linux.

**Meets the contribution criteria:**

- **Popularity**: 1,411 stars (threshold is 50), 163 forks, 23 contributors, ~3.3k downloads per release
- **Template**: `[ACCOUNT/REPO](https://github.com/ACCOUNT/REPO) - DESCRIPTION`. Not published to crates.io, so the `[[CRATE](...)]` part is omitted per CONTRIBUTING
- **Sorting**: placed alphabetically between `Fractalide` and `giga-grabber`
- **Stable and useful**: MIT licensed, actively maintained (latest release v0.2.15, 2026-07-31)

It sits alongside existing entries in this section like `arimxyer/models` and `Tura-AI/tura`.

`markdownlint --config .markdownlint.json README.md` reports no new errors; the single MD039 error on the `supabase-plus` entry is pre-existing on `main`.