### PR TITLE
Add theBGuy/GitDesktop to Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -707,6 +707,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 * [sitkevij/hex](https://github.com/sitkevij/hex) - A colorized hexdump terminal utility.
 * [skim](https://github.com/skim-rs/skim) - A fuzzy finder
 * [supercilex/fuc](https://github.com/supercilex/fuc) - Fast `cp` and `rm` commands
+* [theBGuy/GitDesktop](https://github.com/theBGuy/GitDesktop) - Keyboard-first Git desktop client with PR, issue, discussion, CI and notification management across GitHub, GitLab and Bitbucket, plus Jira linking and AI agent integration; Tauri + Rust backend [![Release](https://github.com/theBGuy/GitDesktop/actions/workflows/release.yml/badge.svg)](https://github.com/theBGuy/GitDesktop/actions/workflows/release.yml)
 * [topheman/webassembly-component-model-experiments](https://github.com/topheman/webassembly-component-model-experiments) - WebAssembly Component Model based REPL with sandboxed multi-language plugin system [![Crates.io](https://img.shields.io/crates/v/pluginlab.svg)](https://crates.io/crates/pluginlab)
 * [trippy](https://github.com/fujiapple852/trippy) - A network diagnostic tool [![build badge](https://github.com/fujiapple852/trippy/workflows/CI/badge.svg)](https://github.com/fujiapple852/trippy/actions/workflows/ci.yml)
 * [tw93/Kaku](https://github.com/tw93/Kaku) - A fast, out-of-the-box terminal emulator built for AI coding, with zero-config defaults, AI assistant integration, and WezTerm-compatible Lua configuration. macOS-only.


### PR DESCRIPTION
Adds an entry for [GitDesktop] to the Applications section of the list, so readers looking for Rust-backed developer tooling can find a keyboard-first Git desktop client.

- Inserts `theBGuy/GitDesktop` into the applications list in `README.md`, placed between `supercilex/fuc` and `topheman/webassembly-component-model-experiments` to preserve the section's alphabetical ordering.
- Describes the project as a keyboard-first Git desktop client covering PR, issue, discussion, CI and notification management across GitHub, GitLab and Bitbucket, with Jira linking and AI agent integration, and notes the Tauri + Rust backend.
- Includes a release workflow status badge linking to the project's `release.yml` GitHub Actions run, matching the badge convention used by neighboring entries.

[GitDesktop]: https://github.com/theBGuy/GitDesktop