### PR TITLE
Add NEURAX - analytical compiler for neural network architectures

### DIFF
--- a/README.md
+++ b/README.md
@@ -935,6 +935,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 * [Wilfred/difftastic](https://github.com/Wilfred/difftastic) [[difftastic](https://crates.io/crates/difftastic)] - A structural diff tool that understands syntax, supporting 30+ programming languages
 * [yvgude/lean-ctx](https://github.com/yvgude/lean-ctx) [[lean-ctx](https://crates.io/crates/lean-ctx)] - Context runtime for AI coding agents: MCP server and shell hook that compresses tool and terminal output to reduce LLM token use; Tree-sitter parsing, session caching. [![CI](https://github.com/yvgude/lean-ctx/actions/workflows/ci.yml/badge.svg)](https://github.com/yvgude/lean-ctx/actions/workflows/ci.yml)
 
+* [NEURAX](https://github.com/rustnew/NEURAX) - Analytical compiler for neural network architectures. Predicts training cost, memory, and performance before training (<50ms, zero GPU). MLIR/LLVM 18 backend.
 ### Build system
 
 * [better-fullstack](https://github.com/Marve10s/Better-Fullstack) - End-to-end fullstack scaffolding tool supporting Rust (Axum, Actix Web, Leptos, Dioxus, SeaORM, SQLx, tonic, async-graphql) alongside TypeScript, Go, and Python — code ready for you or your AI agent.


### PR DESCRIPTION
## What is NEURAX?

[NEURAX](https://github.com/rustnew/NEURAX) is an analytical compiler for neural network architectures. It predicts training cost, memory, and performance **before training** — in under 50ms, with zero GPU, fully deterministically.

- 10-pass analytical IR (Architecture → Graph → Tensor → Operator → Compute → Memory → Parallelism → Hardware → Cost → Report)
- 55+ metrics: FLOPs, VRAM, latency, USD cost, energy, CO2
- 88 reference templates across 11 architecture families (GPT-4, LLaMA-2, Mixtral, DeepSeek-V3, Mamba, SDXL...)
- Custom MLIR backend (10 dialects, LLVM 18)
- 9 crates published on crates.io (neurax-core, neurax-ir, neurax-parser, neurax-formulas, neurax-hardware-db, neurax-mlir, neurax-cli, neurax-tui, neurax-service)
- Benchmarks: 11 models analyzed in <10ms each

## Why it fits

Added under the **Machine learning** section alongside other Rust ML compilers (luminal, candle, burn). NEURAX is the only analytical (design-time) compiler in the list — it complements execution-focused frameworks.