### PR TITLE
Add wakaru to Reverse engineering

### DIFF
--- a/README.md
+++ b/README.md
@@ -2179,6 +2179,7 @@ See also [Are we game yet?](https://arewegameyet.rs)
 * [binlex](https://github.com/c3rb3ru5d3d53c/binlex) - Binary analysis and reverse engineering framework with function fingerprinting and similarity matching.
 * [idalib](https://github.com/idalib-rs/idalib) [[idalib](https://crates.io/crates/idalib)] - Rust bindings for the IDA SDK, enabling the development of standalone analysis tools using IDA v9.0’s idalib
 * [objdiff](https://github.com/encounter/objdiff) - A local diffing tool for decompilation projects
+* [wakaru](https://github.com/pionxzh/wakaru) [[wakaru](https://crates.io/crates/wakaru)] - JavaScript decompiler: unpacks webpack/esbuild/Metro/Browserify bundles into modules and reverses minifier and Babel/TypeScript output into readable code [![CI](https://github.com/pionxzh/wakaru/actions/workflows/rust-ci.yml/badge.svg?branch=main)](https://github.com/pionxzh/wakaru/actions/workflows/rust-ci.yml)
 
 ### Scripting
 


### PR DESCRIPTION
Adds wakaru, an open-source (Apache-2.0) JavaScript decompiler written in Rust on the SWC AST ecosystem: it splits production bundles (webpack/esbuild/Metro/Browserify/…) back into modules and reverses minifier + transpiler output into readable code. 951 stars; `wakaru` is also published on crates.io. Actively maintained; docs + browser playground: https://wakarujs.com/. I'm the maintainer. Placed alphabetically in Reverse engineering, follows the entry template with CI badge.