### PR TITLE
Add MongrelDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -1640,6 +1640,8 @@ See also [About Rust’s Machine Learning Community](https://medium.com/@autumn_
     * [vhbit/lmdb-rs](https://github.com/vhbit/lmdb-rs) [[lmdb-rs](https://crates.io/crates/lmdb-rs)] - Rust bindings for LMDB
   * MongoDB [[mongodb](https://crates.io/keywords/mongodb)]
     * [mongodb/mongo-rust-driver](https://github.com/mongodb/mongo-rust-driver) [[mongodb](https://crates.io/crates/mongodb)] - [MongoDB](https://www.mongodb.com/) bindings
+  * [MongrelDB](https://www.mongreldb.com)
+    * [visorcraft/MongrelDB](https://github.com/visorcraft/MongrelDB) [[mongreldb-core](https://crates.io/crates/mongreldb-core)] - An embedded columnar database engine with SQL, vector search, full-text search, and AI-native retrieval [![build badge](https://github.com/visorcraft/MongrelDB/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/visorcraft/MongrelDB/actions/workflows/ci.yml)
   * [PickleDB](https://pythonhosted.org/pickleDB/)
     * [seladb/pickledb-rs](https://github.com/seladb/pickledb-rs) - a lightweight and simple key-value store, heavily inspired by Python's PickleDB.
   * [PoloDB](https://www.polodb.org/)


### PR DESCRIPTION
- [x] - I have read the [CONTRIBUTING.md](CONTRIBUTING.md) and my pull request fulfills the criteria therein

Adds [MongrelDB](https://github.com/visorcraft/MongrelDB) to Libraries → Database → NoSQL (alphabetically between MongoDB and PickleDB), using the standard template with the `mongreldb-core` crate link and CI badge.

Popularity criteria: the GitHub repo is young (fewer than 50 stars), but the [mongreldb-core crate](https://crates.io/crates/mongreldb-core) has over 2,000 downloads (4.4k+ at submission time), meeting the `stars > 50 | downloads > 2000` bar.

Disclosure: I am submitting on behalf of VisorCraft, the vendor of MongrelDB. MongrelDB itself is open source (MIT OR Apache-2.0); it is not the proprietary Mongrel desktop application.
