### PR TITLE
Add linebender/xilem - experimental reactive UI framework for Rust

### DIFF
--- a/README.md
+++ b/README.md
@@ -1972,6 +1972,7 @@ See also [Are we game yet?](https://arewegameyet.rs)
 * [ivanceras/sauron-native](https://github.com/ivanceras/sauron-native) - A truly native and cross platform GUI library. One unified code can be run as native GUI, Html Web and TUI.
 * [libui](https://github.com/andlabs/libui)
   * [rust-native-ui/libui-rs](https://github.com/rust-native-ui/libui-rs) - libui bindings.
+* [linebender/xilem](https://github.com/linebender/xilem) [[xilem](https://crates.io/crates/xilem)] - Experimental reactive UI framework for Rust inspired by React, SwiftUI, and Elm. Built on Masonry, Vello/wgpu, Parley, and AccessKit with web and native backends. [![CI](https://img.shields.io/github/actions/workflow/status/linebender/xilem/ci.yml?logo=github&label=CI)](https://github.com/linebender/xilem/actions)
 * [longbridge/gpui-component](https://github.com/longbridge/gpui-component) [[gpui-component](https://crates.io/crates/gpui-component)] - UI components for building fantastic desktop applications using GPUI.
 * [makepad/makepad](https://github.com/makepad/makepad) [[makepad-widgets](https://crates.io/crates/makepad-widgets)] - Makepad is a creative software development platform that compiles to wasm/webGL, osx/metal, windows/dx11 linux/opengl.
 * [Nuklear](https://github.com/Immediate-Mode-UI/Nuklear)


### PR DESCRIPTION
- [ ] - I have read the [CONTRIBUTING.md](CONTRIBUTING.md) and my pull request fulfills the criteria therein

## Description
Add [xilem](https://github.com/linebender/xilem) to the Libraries > GUI section.

## About
Xilem is an experimental high-level reactive UI framework for Rust that provides:
-  **Reactive architecture**: Inspired by React, SwiftUI, and Elm with lightweight view tree and declarative updates
-  **Built on Masonry**: Foundational retained widget tree with event handling and update passes
-  **Multi-backend support**: Native backend via Masonry and web backend for cross-platform deployment
-  **Modern graphics stack**: Built on Vello/wgpu for 2D rendering, Parley/Fontique for text, and AccessKit for accessibility
-  **Window management**: Uses winit for cross-platform window creation
-  **Published on crates.io**: Installable via `cargo add xilem`
-  **Active community**: Developed by Linebender collective with Zulip chat support

## Criteria Check
- [x] GitHub stars: > 50
