### PR TITLE
Add zannis/shove (Libraries > Distributed systems)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1714,6 +1714,7 @@ See also [About Rust’s Machine Learning Community](https://medium.com/@autumn_
   * [hyunsik/hdfs-rs](https://github.com/hyunsik/hdfs-rs) [[hdfs](https://crates.io/crates/hdfs)] - libhdfs bindings
 * Other
   * [build-trust/ockam](https://github.com/build-trust/ockam) [[ockam](https://crates.io/crates/ockam)] - End-to-End Encryption, Mutual Authentication, and ABAC for distributed applications [![build badge](https://github.com/build-trust/ockam/workflows/Rust/badge.svg)](https://github.com/build-trust/ockam)
+  * [zannis/shove](https://github.com/zannis/shove) [[shove](https://crates.io/crates/shove)] - Type-safe async pub/sub with one consistent API over RabbitMQ, Kafka, NATS JetStream, AWS SNS/SQS, and Redis Streams, with retries, DLQ routing, and autoscaling consumer groups [![CI](https://github.com/zannis/shove/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/zannis/shove/actions/workflows/ci.yml)
 
 ### Domain driven design
 


### PR DESCRIPTION
Adds [shove](https://github.com/zannis/shove) [[crates.io](https://crates.io/crates/shove)] under **Libraries → Distributed systems → Other**: a type-safe async pub/sub library with one consistent API over RabbitMQ, Kafka, NATS JetStream, AWS SNS/SQS, and Redis Streams, with retries, DLQ routing, and autoscaling consumer groups.

Popularity metric per CONTRIBUTING.md: **3,933 downloads on crates.io** (2,968 in the last 90 days), above the 2,000-download threshold.

Entry follows the template, includes the CI badge with branch info, and is placed in alphabetical order.