### PR TITLE
Add Ironpress to Libraries > Graphics > PDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -1934,6 +1934,7 @@ See also [Are we game yet?](https://arewegameyet.rs)
 * PDF
   * [bastibense/libharu_ng](https://github.com/bastibense/libharu_ng) [[libharu_ng](https://crates.io/crates/libharu_ng)] - Easily generate PDFs from your Rust app.
   * [fschutt/printpdf](https://github.com/fschutt/printpdf) - PDF writing library
+  * [gastongouron/ironpress](https://github.com/gastongouron/ironpress) [[ironpress](https://crates.io/crates/ironpress)] - Pure Rust HTML/CSS/Markdown-to-PDF converter with a built-in layout engine and no browser or system dependencies. [![CI](https://github.com/gastongouron/ironpress/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/gastongouron/ironpress/actions/workflows/ci.yml)
   * [J-F-Liu/lopdf](https://github.com/J-F-Liu/lopdf) - PDF document manipulation
   * [kaj/rust-pdf](https://github.com/kaj/rust-pdf) - Generating PDF files in pure Rust
   * [yfedoseev/pdf_oxide](https://github.com/yfedoseev/pdf_oxide) [[pdf_oxide](https://crates.io/crates/pdf_oxide)] - Fast PDF text extraction, creation, and editing with Python bindings


### PR DESCRIPTION
## Summary

Adds [gastongouron/ironpress](https://github.com/gastongouron/ironpress) to **Libraries → Graphics → PDF**.

IronPress converts HTML, CSS, and Markdown to PDF in pure Rust using a built-in layout engine, without a browser or system dependencies. It is available as both a Rust library and a CLI through the published [ironpress crate](https://crates.io/crates/ironpress).

I am the maintainer of IronPress.

## Eligibility

- GitHub: **237 stars**, above the 50-star threshold
- crates.io: **2,415 total downloads**, above the 2,000-download threshold

## Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) and my pull request fulfills the criteria therein
- [x] Uses the required repository and crate template
- [x] Placed alphabetically between fschutt/printpdf and J-F-Liu/lopdf
- [x] Includes the GitHub Actions CI badge with branch=main
- [x] Changes only one README entry