### PR TITLE
Add Nudge - typed programming language for LLM agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,6 +476,7 @@ See also [Games Made With Piston](https://github.com/PistonDevelopers/piston/wik
 * [Rocketmq-Rust](https://github.com/mxsm/rocketmq-rust) - 🚀Apache RocketMQ build in Rust🦀. Faster, safer, and with lower memory usage.
 
 ### MLOps
+* [Nudge](https://github.com/NekomyaDev/nudge) - A typed, replayable, budget-aware programming language for LLM agents. Compiles to Python & TypeScript. [![CI](https://github.com/NekomyaDev/nudge/actions/workflows/ci.yml/badge.svg)](https://github.com/NekomyaDev/nudge/actions/workflows/ci.yml)
 
 * [cocoindex](https://github.com/cocoindex-io/cocoindex) - ETL framework to build fresh context for AI agents, with incremental processing
 * [TensorZero](https://github.com/tensorzero/tensorzero) - data & learning flywheel for LLMs that unifies inference, observability, optimization, and experimentation ![TensorZero Build Status](https://img.shields.io/github/check-runs/tensorzero/tensorzero/main)


### PR DESCRIPTION
## What

Added [Nudge](https://github.com/NekomyaDev/nudge) to the MLOps section.

## Why

Nudge is a typed, replayable, budget-aware programming language for LLM agents, written in Rust. It features:

- Typed LLM calls with schema validation
- Deterministic replay and trace-based testing
- Budget contracts for cost control
- Effect system (pure / LLM / Tool / IO)
- Native parallelism (par map/race/all)
- Compiles to Python & TypeScript
- Zero dependencies, single binary

## Links

- GitHub: https://github.com/NekomyaDev/nudge
- VS Code Extension: https://marketplace.visualstudio.com/items?itemName=Nekomya.nudge-lang