### PR TITLE
Add fnprint under Reverse engineering

### DIFF
--- a/README.md
+++ b/README.md
@@ -2182,6 +2182,7 @@ See also [Are we game yet?](https://arewegameyet.rs)
 ### Reverse engineering
 
 * [binlex](https://github.com/c3rb3ru5d3d53c/binlex) - Binary analysis and reverse engineering framework with function fingerprinting and similarity matching.
+* [fnprint](https://github.com/1rhino2/fnprint) [[fnprint](https://crates.io/crates/fnprint)] - Identifies functions in stripped binaries by behavior (microexecution) instead of byte signatures; cross-compiler and training-free, with an n-day patch-diffing triage mode.
 * [idalib](https://github.com/idalib-rs/idalib) [[idalib](https://crates.io/crates/idalib)] - Rust bindings for the IDA SDK, enabling the development of standalone analysis tools using IDA v9.0’s idalib
 * [objdiff](https://github.com/encounter/objdiff) - A local diffing tool for decompilation projects
 * [wakaru](https://github.com/pionxzh/wakaru) [[wakaru](https://crates.io/crates/wakaru)] - JavaScript decompiler: unpacks webpack/esbuild/Metro/Browserify bundles into modules and reverses minifier and Babel/TypeScript output into readable code [![CI](https://github.com/pionxzh/wakaru/actions/workflows/rust-ci.yml/badge.svg?branch=main)](https://github.com/pionxzh/wakaru/actions/workflows/rust-ci.yml)


### PR DESCRIPTION
fnprint identifies functions in stripped binaries by what they do (microexecution) instead of byte signatures, so matches survive recompiles and different opt levels, and it has an n-day patch-diffing triage mode (rank the changed function between vuln and patched builds).

Published on crates.io, MIT, x86-64 ELF for now, with a reproducible accuracy table and honest limits in the readme. Added under Reverse engineering, alphabetical, with the crates.io link.