### PR TITLE
Add rsasaki0109/rust_robotics

### DIFF
--- a/README.md
+++ b/README.md
@@ -2213,6 +2213,7 @@ See also [Are we game yet?](https://arewegameyet.rs)
 [[simulation](https://crates.io/keywords/simulation)]
 
 * [nyx-space](https://crates.io/crates/nyx-space) - High fidelity, fast, reliable and validated astrodynamical toolkit library, used for spacecraft mission design and orbit determination [![Build Status](https://gitlab.com/nyx-space/nyx/badges/master/pipeline.svg)](https://gitlab.com/nyx-space/nyx/-/pipelines)
+* [rsasaki0109/rust_robotics](https://github.com/rsasaki0109/rust_robotics) [[rust_robotics](https://crates.io/crates/rust_robotics)] - Rust implementations of robotics algorithms inspired by PythonRobotics, covering path planning, localization, SLAM, and control, with no_std support and ROS 2 examples [![CI](https://github.com/rsasaki0109/rust_robotics/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/rsasaki0109/rust_robotics/actions/workflows/ci.yml)
 
 ### Social networks
 


### PR DESCRIPTION
Adds [rsasaki0109/rust_robotics](https://github.com/rsasaki0109/rust_robotics) to the **Libraries → Simulation** section, following the entry template with the crates.io link and CI badge.

- Rust implementations of robotics algorithms inspired by PythonRobotics (path planning, localization, SLAM, control), with `no_std` support and ROS 2 examples.
- Meets the popularity criterion with **253 GitHub stars** (> 50).
- MIT licensed, actively maintained, published on [crates.io](https://crates.io/crates/rust_robotics).