### PR TITLE
Add shleder/vetto to Security tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,6 +615,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 * [sherlock](https://github.com/jonaylor89/sherlock-rs) [[sherlock](https://crates.io/crates/sherlock)] - Hunt down social media accounts by username across social networks [![status](https://github.com/jonaylor89/sherlock-rs/actions/workflows/rust.yml/badge.svg)](https://github.com/jonaylor89/sherlock-rs/actions/workflows/rust.yml)
 * [ssh-vault](https://github.com/ssh-vault/ssh-vault) - A simple tool to manage secrets using ssh keys for encryption and decryption.
 * [timescale/rsigma](https://github.com/timescale/rsigma) [[rsigma](https://crates.io/crates/rsigma)] - A complete detection engineering toolkit for the Sigma detection standard, with a parser, evaluation engine, rule conversion, streaming runtime, linter, CLI, MCP, and LSP [![CI](https://github.com/timescale/rsigma/actions/workflows/ci.yml/badge.svg)](https://github.com/timescale/rsigma/actions/workflows/ci.yml)
+* [shleder/vetto](https://github.com/shleder/vetto) - Daemon-less sandbox and security layer for AI coding agents: Landlock/seccomp on Linux and Seatbelt on macOS, fail-closed launch, network off by default, copy-only recovery of lost Codex sessions
 
 ### Social networks
 


### PR DESCRIPTION
**What:** [vetto](https://github.com/shleder/vetto) — a daemon-less sandbox and security layer for AI coding agents, written in Rust, Apache-2.0.

**Why it fits Security tools:** kernel-enforced isolation for running untrusted agent workloads (Landlock + namespaces + seccomp on Linux, Seatbelt on macOS), fail-closed launch policy (no unsandboxed fallback), network off by default with a DNS-pinned allowlist relay, and post-session evidence reports (JSONL/HTML/SARIF). It also includes a copy-only recovery tool for lost Codex CLI session transcripts.

**Details:**
- Active project, public repo, installable via npm (@shleddy/vetto) with prebuilt binaries; builds from source with cargo build --locked
- Placed alphabetically at the end of the section (after timescale/rsigma)
- Entry follows the existing one-line format without badges (no crates.io release yet)

If the maintainers prefer a different phrasing or section placement, happy to adjust.