### PR TITLE
Add koscak-labs/struktura to Science

### DIFF
--- a/README.md
+++ b/README.md
@@ -1488,6 +1488,7 @@ See also [About Rust’s Machine Learning Community](https://medium.com/@autumn_
   * [Axect/Peroxide](https://github.com/Axect/Peroxide) - Rust numeric library containing linear algebra, numerical analysis, statistics and machine learning tools in pure rust
   * [cool-japan/scirs](https://github.com/cool-japan/scirs) - Production-Ready pure Rust scientific computing, includes linear algebra, optimization, statistics, neural networks and more. API inspired by Python's SciPy.
   * [cpmech/russell](https://github.com/cpmech/russell) - Rust Scientific Library for numerical mathematics, ordinary differential equations, special math functions, high-performance (sparse) linear algebra
+  * [koscak-labs/struktura](https://github.com/koscak-labs/struktura) [[struktura](https://crates.io/crates/struktura)] - DFA anomaly detection for time-series — spacecraft, bearings, finance, text. no_std compatible. [![CI](https://github.com/koscak-labs/struktura/actions/workflows/ci.yml/badge.svg)](https://github.com/koscak-labs/struktura/actions/workflows/ci.yml)
   * [Nonanti/mathcore](https://github.com/Nonanti/mathcore) - Symbolic mathematics library with CAS capabilities. Supports differentiation, integration, equation solving, and arbitrary precision arithmetic [![crates.io](https://img.shields.io/crates/v/mathcore.svg)](https://crates.io/crates/mathcore)
   * [Ryan-D-Gast/differential-equations](https://github.com/Ryan-D-Gast/differential-equations) - A high-performance library for numerically solving differential equations
 * Statrs


### PR DESCRIPTION
Adds [struktura](https://crates.io/crates/struktura), a DFA (Detrended Fluctuation Analysis) anomaly detection crate for time-series data.

Tested on NASA IMS bearing failure and Voyager 1 heliopause data. `no_std` compatible, 85x faster than Python alternatives. CI badge included.