### PR TITLE
Add wickra-lib/wickra to Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1845,6 +1845,7 @@ See also [About Rust’s Machine Learning Community](https://medium.com/@autumn_
 * [d-e-s-o/apca](https://github.com/d-e-s-o/apca) [[apca](https://crates.io/crates/apca)] - Opinionated and comprehensive bindings to the [Alpaca API](https://alpaca.markets/) for stock trading and more. ![GitHub Workflow Status](https://github.com/d-e-s-o/apca/actions/workflows/test.yml/badge.svg?branch=main)
 * [kand-ta/kand](https://github.com/kand-ta/kand) [[kand](https://crates.io/crates/kand)] - A Modern, High-Performance Technical Analysis Library in Rust, Python, and JS/TS(WASM). [![image](https://img.shields.io/crates/v/kand.svg)](https://crates.io/crates/kand)
 * [stochastic-rs](https://github.com/rust-dd/stochastic-rs) [[stochastic-rs](https://crates.io/crates/stochastic-rs)] - High-performance data generation library for stochastic process with quant finance tools. ![GitHub Workflow Status](https://github.com/rust-dd/stochastic-rs/actions/workflows/rust.yml/badge.svg)
+* [wickra-lib/wickra](https://github.com/wickra-lib/wickra) [[wickra](https://crates.io/crates/wickra)] - Streaming-first technical analysis: 514 indicators with O(1) per-tick updates, from a Rust core with native Python, Node.js and WASM bindings plus a C ABI hub for C, C++, C#, Go, Java and R. [![CI](https://github.com/wickra-lib/wickra/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/wickra-lib/wickra/actions/workflows/ci.yml)
 
 ### Functional Programming
 


### PR DESCRIPTION
- [x] - I have read the [CONTRIBUTING.md](CONTRIBUTING.md) and my pull request fulfills the criteria therein

Adds [wickra-lib/wickra](https://github.com/wickra-lib/wickra) [[wickra](https://crates.io/crates/wickra)] under **Libraries → Finance**, in alphabetical order after `stochastic-rs`.

**Popularity metric per CONTRIBUTING.md:** 3,829 downloads on crates.io, 50 stars on GitHub.

**What it is:** a streaming-first technical analysis library — 514 indicators that update in O(1) per tick instead of recomputing over a window. Rust core with native Python, Node.js and WebAssembly bindings plus a C ABI hub for C, C++, C#, Go, Java and R. Dual MIT OR Apache-2.0, CI on Linux, macOS and Windows, currently v1.0.1.