### PR TITLE
Add loco-rs/loco to Web programming / Backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -2314,6 +2314,7 @@ See also [Are we web yet?](https://www.arewewebyet.org) and [Rust web framework 
 * Backend
   * [actix/actix-web](https://github.com/actix/actix-web) - A lightweight async web framework with websocket support
   * [Anansi](https://github.com/saru-tora/anansi) - A simple full-stack web framework
+  * [loco-rs/loco](https://github.com/loco-rs/loco) [[loco-rs](https://crates.io/crates/loco-rs)] - The one-person framework for Rust for side-projects and startups, inspired by Rails. [![Build](https://github.com/loco-rs/loco/actions/workflows/ci.yml/badge.svg)](https://github.com/loco-rs/loco/actions)
   * [Rocket](https://github.com/rwf2/Rocket) - Rocket is a web framework with a focus on ease-of-use, expressability, and speed
   * [RustAPI](https://github.com/Tuntii/RustAPI) [[rustapi-rs](https://crates.io/crates/rustapi-rs)] - Ergonomic web framework with compile-time OpenAPI and native MCP
   * [summer-rs](https://github.com/summer-rs/summer-rs) - summer-rs is a application framework written in rust inspired by java's spring-boot.


### PR DESCRIPTION
## Description
- Adds `loco-rs/loco` under `### Web programming -> * Backend` in alphabetical order.
- [loco-rs](https://github.com/loco-rs/loco) (crates.io: `loco-rs`) is the leading batteries-included one-person web framework for Rust, inspired by Ruby on Rails with built-in Tokio/Axum/SeaORM support and 9,000+ GitHub stars.