### PR TITLE
Add waxum to Applications/Social networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -628,6 +628,8 @@ See also [A comparison of operating systems written in Rust](https://github.com/
   * [Rustodon](https://github.com/rustodon/rustodon) - A Mastodon-compatible, ActivityPub-speaking server.
 * Telegram
   * [tgt](https://github.com/FedericoBruzzone/tgt) - A crossplatform TUI for Telegram [![ci-linux](https://github.com/FedericoBruzzone/tgt/actions/workflows/ci-linux.yml/badge.svg)](https://github.com/FedericoBruzzone/tgt/actions/workflows/ci-linux.yml) [![ci-macos](https://github.com/FedericoBruzzone/tgt/actions/workflows/ci-macos.yml/badge.svg)](https://github.com/FedericoBruzzone/tgt/actions/workflows/ci-macos.yml) [![ci-windows](https://github.com/FedericoBruzzone/tgt/actions/workflows/ci-windows.yml/badge.svg)](https://github.com/FedericoBruzzone/tgt/actions/workflows/ci-windows.yml)
+* WhatsApp
+  * [imtaqin/waxum](https://github.com/imtaqin/waxum) - Self-hosted WhatsApp gateway exposing a REST API, webhooks, multi-session support and voice calls from a single static binary. [![CI](https://github.com/imtaqin/waxum/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/imtaqin/waxum/actions/workflows/ci.yml)
 
 ### System tools
 


### PR DESCRIPTION
Adds [waxum](https://github.com/imtaqin/waxum) under **Applications → Social networks → WhatsApp**.

Waxum is a self-hosted WhatsApp gateway: you run one binary, it holds the WhatsApp sessions and exposes them over a REST API plus webhooks, so any language can drive it.

### Eligibility per CONTRIBUTING.md

- **Popularity:** 106 stars (threshold is >50). Not published to crates.io — it is a server binary, not a library — so the `[[CRATE](...)]` part of the template is omitted as the guidelines allow.
- **Template:** `[ACCOUNT/REPO](https://github.com/ACCOUNT/REPO) - DESCRIPTION` + CI build badge with branch information, as requested.
- **Ordering:** `WhatsApp` is placed after `Telegram`, keeping the platform bullets alphabetical.

### On the new `WhatsApp` sub-bullet

I added a platform sub-bullet rather than a flat entry, to match how this section already groups by platform (Discord / Mastodon / Telegram). It follows the existing precedent of a single-entry platform group — `Mastodon` currently holds one item. If you would rather see this as a flat entry under **Applications → Web** (next to `hook0/hook0`), say the word and I will move it — happy to go whichever way you prefer.

### Project details

- Written in Rust; ships as a single static binary — no Node, Python, or headless browser runtime required.
- 180+ REST endpoints across 29 feature modules: messaging, groups, contacts, presence, media, webhooks, voice calls.
- Multi-session, with Postgres / MySQL / SQLite backends.
- Built-in web console and OpenAPI/Swagger UI.
- Actively maintained — 50 tagged releases, first released 2026-03-26.
- MIT licensed ([LICENSE](https://github.com/imtaqin/waxum/blob/dev/LICENSE)).
