### PR TITLE
Add cargo-machete to Build system

### DIFF
--- a/README.md
+++ b/README.md
@@ -963,6 +963,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
   * [cargo-info](https://crates.io/crates/cargo-info) - queries crates.io for crates details from command line
   * [cargo-license](https://crates.io/crates/cargo-license) - A cargo subcommand to quickly view the licenses of all dependencies.
   * [cargo-limit](https://crates.io/crates/cargo-limit) - Cargo with less noise: warnings are skipped until errors are fixed, Neovim integration, etc. [![build badge](https://github.com/cargo-limit/cargo-limit/actions/workflows/ci.yml/badge.svg)](https://github.com/cargo-limit/cargo-limit/actions)
+  * [cargo-machete](https://github.com/bnjbvr/cargo-machete) [[cargo-machete](https://crates.io/crates/cargo-machete)] - Simple tool for detecting unused dependencies in Cargo.toml.
   * [cargo-make](https://crates.io/crates/cargo-make) - Task runner and build tool. [![build badge](https://github.com/sagiegurari/cargo-make/workflows/CI/badge.svg?branch=master)](https://github.com/sagiegurari/cargo-make/actions)
   * [cargo-modules](https://crates.io/crates/cargo-modules) - A cargo plugin for showing a tree-like overview of a crate's modules.
   * [cargo-multi](https://crates.io/crates/cargo-multi) - runs specified cargo command on multiple crates


### PR DESCRIPTION
## Description
- Adds `cargo-machete` under `### Build system -> * Cargo` in alphabetical order.
- [cargo-machete](https://github.com/bnjbvr/cargo-machete) is a fast and simple cargo subcommand for detecting unused dependencies in Cargo.toml.