### PR TITLE
Add api7/aisix to Applications/MLOps

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,6 +480,7 @@ See also [Games Made With Piston](https://github.com/PistonDevelopers/piston/wik
 
 ### MLOps
 
+* [api7/aisix](https://github.com/api7/aisix) - Open-source AI gateway for LLMs and AI agents: one OpenAI-compatible API plus a native Anthropic Messages API in front of OpenAI, Anthropic, Gemini, Bedrock, Azure OpenAI, and other OpenAI-compatible endpoints, with MCP and A2A gateways, semantic routing, guardrails, and semantic caching. [![CI](https://github.com/api7/aisix/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/api7/aisix/actions/workflows/ci.yml)
 * [cocoindex](https://github.com/cocoindex-io/cocoindex) - ETL framework to build fresh context for AI agents, with incremental processing
 * [TensorZero](https://github.com/tensorzero/tensorzero) - data & learning flywheel for LLMs that unifies inference, observability, optimization, and experimentation ![TensorZero Build Status](https://img.shields.io/github/check-runs/tensorzero/tensorzero/main)
 * [Uteke](https://github.com/codecoradev/uteke) - Offline-first semantic memory engine for AI agents. Single binary, zero dependencies, MCP-native. [![CI](https://img.shields.io/github/actions/workflow/status/codecoradev/uteke/ci.yml?branch=develop)](https://github.com/codecoradev/uteke/actions/workflows/ci.yml)


### PR DESCRIPTION
Adds [api7/aisix](https://github.com/api7/aisix), an open-source AI gateway for LLMs and AI agents written in Rust (Apache-2.0, single static binary).

Checklist against CONTRIBUTING.md:

- Popularity bar: 127 stars on GitHub (> 50)
- Template followed: `[ACCOUNT/REPO](https://github.com/ACCOUNT/REPO) - DESCRIPTION`; the `[[CRATE]]` part is omitted because the project is not published on crates.io
- CI badge included with branch information (`?branch=main`)
- Alphabetical ordering: `api7/aisix` is placed before `cocoindex` in Applications/MLOps

Section choice: Applications/MLOps, alongside TensorZero — AISIX is likewise a deployable application for serving and governing LLM traffic (provider routing, guardrails, caching, observability) rather than a library.