### PR TITLE
Add numr to computation libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1499,6 +1499,7 @@ See also [About Rust’s Machine Learning Community](https://medium.com/@autumn_
 * [jolars/basin](https://github.com/jolars/basin) [[basin](https://crates.io/crates/basin)] - Numerical optimization library with first-order, derivative-free, nonlinear least-squares, evolutionary, and constrained solvers, generic over linear-algebra backends [![CI](https://github.com/jolars/basin/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/jolars/basin/actions/workflows/ci.yml)
 * [LAPACK](https://en.wikipedia.org/wiki/LAPACK)
   * [stainless-steel/lapack](https://github.com/blas-lapack-rs/lapack) - LAPACK bindings
+* [ml-rust/numr](https://github.com/ml-rust/numr) [[numr](https://crates.io/crates/numr)] - Numerical computing library for Rust inspired by NumPy, with tensors, linear algebra, FFT, statistics, automatic differentiation, and GPU acceleration. [![CI](https://github.com/ml-rust/numr/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/ml-rust/numr/actions/workflows/ci.yml)
 * Parallel
   * [arrayfire/arrayfire-rust](https://github.com/arrayfire/arrayfire-rust) - [Arrayfire](https://github.com/arrayfire) bindings
   * [autumnai/collenchyma](https://github.com/autumnai/collenchyma) - An extensible, pluggable, backend-agnostic framework for parallel, high-performance computations on CUDA, OpenCL and common host CPU.


### PR DESCRIPTION
Added [ml-rust/numr](https://github.com/ml-rust/numr) to README.md under Computation.

**numr** is a numerical computing library for Rust inspired by NumPy. It provides tensors, linear algebra, FFT, statistics, automatic differentiation, and GPU acceleration.

- [x] Read CONTRIBUTING.md
- [x] Meets the 50-star requirement
- [x] Follows the entry template
- [x] Keeps alphabetical order
- [x] Includes the crate link and CI badge