### PR TITLE
Add fastalp under Compression section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1466,6 +1466,8 @@ See also [About Rust’s Machine Learning Community](https://medium.com/@autumn_
 
 * [7z](https://7-zip.org/7z.html)
   * [[sevenz-rust](https://crates.io/crates/sevenz-rust)] - A 7z decompressor/compressor written in pure rust.
+* [ALP](https://github.com/webc-site/wedb_embed/tree/main/fastalp)
+  * [fastalp](https://github.com/webc-site/wedb_embed/tree/main/fastalp) [[fastalp](https://crates.io/crates/fastalp)] - Adaptive Lossless Floating-Point (ALP) compression algorithm for f32 and f64
 * [Brotli](https://opensource.googleblog.com/2015/09/introducing-brotli-new-compression.html)
   * [dropbox/rust-brotli](https://github.com/dropbox/rust-brotli) - Brotli decompressor that optionally avoids the stdlib
   * [ende76/brotli-rs](https://github.com/ende76/brotli-rs) - implementation of Brotli compression


### PR DESCRIPTION
Add [fastalp](https://github.com/webc-site/fastalp) under the Compression section.

fastalp is a pure Rust implementation of the Adaptive Lossless Floating-Point (ALP) compression algorithm (SIGMOD 2024) for f32 and f64, available on [crates.io](https://crates.io/crates/fastalp).

Benchmark and implementation characteristics:
- Decompression throughput: Achieves 23.55 GB/s geometric mean across all 37 benchmarks (peaking between 55 and 77 GB/s) via pure-register SIMD auto-vectorization.
- Compression throughput: Reaches 3.55 GB/s geometric mean end-to-end compression (4.4 to 6.8 GB/s in regular blocks, and 15 to 20+ GB/s with parameter caching).
- Compression ratio: Averages 6.83x geometric mean across all 37 benchmarks (2.29x on the 31 ALP paper datasets).
- Zero-heap APIs: Provides compress_into and decompress_into interfaces writing directly into caller buffers.
- Safeguards: Built-in raw fallback prevents payload expansion on high-entropy data.

![fastalp Floating-Point Compression Performance & Ratio Benchmark](https://fastly.jsdelivr.net/gh/webc-fs/-@53/SLHLoauQAr1wmk3FJZTQ.svg)
