### PR TITLE
Add tenequm/pond to Artificial Intelligence > Tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1302,6 +1302,7 @@ See also [About Rust’s Machine Learning Community](https://medium.com/@autumn_
 * [juyterman1000/entroly](https://github.com/juyterman1000/entroly) - Information-theoretic Context Engineering Engine that uses reinforcement learning to intelligently prune and select optimal RAG fragments.
 * [memvid/memvid](https://github.com/memvid/memvid) [[memvid-core](https://crates.io/crates/memvid-core)] - A single-file portable memory layer for AI agents with vector search, full-text search, and long-term recall packed into one `.mv2` file
 * [pydantic/monty](https://github.com/pydantic/monty) - A minimal, secure Python interpreter for running LLM-generated code in AI agents, with microsecond startup, strict sandboxing, and snapshotting support [![CI](https://github.com/pydantic/monty/actions/workflows/ci.yml/badge.svg)](https://github.com/pydantic/monty/actions/workflows/ci.yml)
+* [tenequm/pond](https://github.com/tenequm/pond) [[pond-db](https://crates.io/crates/pond-db)] - Lossless storage and search for AI agent sessions across twelve coding-agent clients, built on Lance over a local directory or an S3 bucket, with BM25 and optional vector retrieval exposed over CLI, HTTP, MCP and read-only SQL [![build badge](https://github.com/tenequm/pond/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/tenequm/pond/actions/workflows/ci.yml)
 
 ### Astronomy
 


### PR DESCRIPTION
pond is lossless storage and search for AI agent sessions, written in Rust and built directly on the `lance-format/lance` crates (no lancedb wrapper). It ingests the session files twelve coding-agent harnesses already write - Claude Code, Codex CLI, opencode, pi, oh-my-pi, OpenClaw, NanoClaw, Hermes, letta-code, grok-build, Claude desktop, claude.ai export - into a local directory or an S3/GCS/Azure bucket, and exposes search over CLI, HTTP+JSON, MCP, and read-only SQL (DataFusion over the same Lance datasets). Retrieval is BM25 by default, with optional local embeddings (Metal / CUDA / CPU).

Meets the inclusion bar: 58 stars (> 50); the crate `pond-db` has 1,224 downloads. Apache-2.0, CI green, released continuously since May 2026 (currently v0.17.0), also distributed via Homebrew, Scoop, and Nix.

Placement: `Libraries > Artificial Intelligence > Tooling`, alphabetically after `pydantic/monty`, using the `ACCOUNT/REPO [[CRATE]] - DESCRIPTION` template with a branch-pinned build badge. It sits next to `memvid/memvid` and `Cortex Memory`, which occupy the same shelf. If maintainers would rather see it under `Applications`, say the word and I will move it - it installs a `pond` binary as well as being a crate.

Disclosure: I am the author.
