### PR TITLE
Add zion (TLS reverse proxy with WAF) to Web Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -872,6 +872,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 
 * [cloudflare/pingora](https://github.com/cloudflare/pingora) - A library for building fast, reliable and evolvable network services.
 * [emanuele-em/proxelar](https://github.com/emanuele-em/proxelar) - A MITM Proxy 🦀! Toolkit for HTTP/1, HTTP/2, and WebSockets with SSL/TLS Capabilities [![Rust](https://github.com/emanuele-em/proxelar/actions/workflows/autofix.yml/badge.svg)](https://github.com/emanuele-em/proxelar/actions)
+* [fabriziosalmi/zion](https://github.com/fabriziosalmi/zion) - High-performance TLS reverse proxy with a built-in Web Application Firewall.
 * [g3proxy](https://github.com/bytedance/g3) - Forward proxy server, support Proxy Chaining, Protocol Inspection, MITM Interception, ICAP Adaptation, Transparent Proxy [![CodeCoverage](https://github.com/bytedance/g3/actions/workflows/codecov.yml/badge.svg)](https://github.com/bytedance/g3/actions)
 * [hyperlane-dev/hyperlane](https://github.com/hyperlane-dev/hyperlane) [[hyperlane](https://crates.io/crates/hyperlane)] - A lightweight, high-performance, cross-platform Rust HTTP server library built on Tokio; built-in support for middleware, WebSocket, SSE, and raw TCP. [![CI](https://github.com/hyperlane-dev/hyperlane/actions/workflows/rust.yml/badge.svg)](https://github.com/hyperlane-dev/hyperlane/actions)
 * [Mini RPS](https://github.com/marcodpt/minirps) - Mini reverse proxy server, HTTPS, CORS, static file hosting and template engine (minijinja) [crates.io](https://crates.io/crates/minirps)


### PR DESCRIPTION
Adds **zion** to *Applications → Web Servers*, alphabetically between `emanuele-em/proxelar` and `g3proxy`.

`* [fabriziosalmi/zion](https://github.com/fabriziosalmi/zion) - High-performance TLS reverse proxy with a built-in Web Application Firewall.`

- Written in Rust (rustls-based), Apache-2.0 licensed, actively developed.
- Fits alongside the other Rust reverse/forward proxies already listed (pingora, g3proxy, proxelar, rama, vproxy).
- Single entry, single PR; description ends with a period.