### PR TITLE
Add PicoNote to applications list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ If you want to contribute, please read [this](CONTRIBUTING.md).
 ## Applications
 
 * [ad-si/Woxi](https://github.com/ad-si/Woxi) [[woxi](https://crates.io/crates/woxi)] - An interpreter for the Wolfram Language powered by Rust.
+* [PicoNote](https://github.com/kullanici_adiniz/piconote) - A lightweight, local-first note-taking app with WebDAV sync built with Tauri v2 and Rust.
 * [alacritty](https://github.com/alacritty/alacritty) - A cross-platform, GPU enhanced terminal emulator
 * [Andromeda](https://github.com/tryandromeda/andromeda) - JavaScript & TypeScript runtime built from the ground up in Rust 🦀 and powered by The Nova Engine.
 * [arimxyer/models](https://github.com/arimxyer/models) [[modelsdev](https://crates.io/crates/modelsdev)] - A TUI for browsing AI models, benchmarks, and coding agents [![CI](https://github.com/arimxyer/models/actions/workflows/ci.yml/badge.svg)](https://github.com/arimxyer/models/actions/workflows/ci.yml)


### PR DESCRIPTION
Added PicoNote as a new application in the README.

- [ ] - I have read the [CONTRIBUTING.md](CONTRIBUTING.md) and my pull request fulfills the criteria therein
