### PR TITLE
Add Vetto: daemon-less kernel sandbox for AI coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -596,6 +596,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 * [cargo-auditable](https://crates.io/crates/cargo-auditable) - Make production Rust binaries auditable
 * [cargo-crev](https://crates.io/crates/cargo-crev) - A cryptographically verifiable code review system for the cargo package manager.
 * [cargo-deny](https://crates.io/crates/cargo-deny) - Cargo plugin to help you manage large dependency graphs
+* [vetto](https://github.com/shleder/vetto) [[vetto](https://crates.io/crates/vetto)] - Daemon-less kernel sandbox for AI coding agents (Landlock/seccomp/namespaces, 20 agent profiles, `vetto enable <agent>`)
 * [Cherrybomb](https://github.com/blst-security/cherrybomb) - Stop half-done API specifications with a CLI tool that helps you avoid undefined user behaviour by validating your API specifications.
 * [cotp](https://github.com/replydev/cotp) - Trustworthy, encrypted, command-line TOTP/HOTP authenticator app with import functionality.
 * [domcyrus/rustnet](https://github.com/domcyrus/rustnet) - Cross-platform network monitoring TUI with process identification via eBPF/PKTAP and deep packet inspection [![build badge](https://img.shields.io/github/actions/workflow/status/domcyrus/rustnet/rust.yml?logo=github)](https://github.com/domcyrus/rustnet/actions/workflows/rust.yml) [![crate](https://img.shields.io/crates/v/rustnet-monitor?logo=rust)](https://crates.io/crates/rustnet-monitor)


### PR DESCRIPTION
Adds Vetto to Development tools.

Vetto (https://github.com/shleder/vetto, Apache-2.0, on crates.io as `vetto`) is a daemon-less kernel sandbox for AI coding agents written in Rust: Landlock ABI 1-6 + user/mount/net namespaces + hand-built seccomp-BPF on Linux, Seatbelt on macOS, zero daemons. `vetto enable <agent>` wraps 20 coding CLIs (Claude Code, Codex, Gemini, Aider, …) so secret reads and off-allowlist egress are denied by the kernel.

Disclosure: I am the author/maintainer of Vetto.
