### PR TITLE
Add Ferrum to Machine learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1288,6 +1288,7 @@ See also [About Rust’s Machine Learning Community](https://medium.com/@autumn_
 * [raphaelmansuy/edgequake](https://github.com/raphaelmansuy/edgequake) - A high-performance Graph-RAG framework that transforms documents into intelligent knowledge graphs.
 * [rust-ml/linfa](https://github.com/rust-ml/linfa) - Machine learning framework.
 * [sipemu/anofox-regression](https://github.com/sipemu/anofox-regression) [[anofox-regression](https://crates.io/crates/anofox-regression)] - Statistical regression models (OLS, Elastic Net, GLM, Quantile & Isotonic) with R-like inference (p-values, confidence & prediction intervals) and Wasm support.
+* [sizzlecar/ferrum-infer-rs](https://github.com/sizzlecar/ferrum-infer-rs) [[ferrum-engine](https://crates.io/crates/ferrum-engine)] - Local LLM inference runtime with a CLI, Apple Silicon Metal support, and an OpenAI-compatible API. [![CI](https://github.com/sizzlecar/ferrum-infer-rs/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/sizzlecar/ferrum-infer-rs/actions/workflows/ci.yml)
 * [smartcorelib/smartcore](https://github.com/smartcorelib/smartcore) - Machine Learning Library [![Build Status](https://img.shields.io/circleci/build/github/smartcorelib/smartcore)]
 * [tag1consulting/feste](https://github.com/tag1consulting/feste) - A GPT-2 style transformer language model implemented from scratch in Rust for educational purposes.
 * [tensorflow/rust](https://github.com/tensorflow/rust) - Bindings for TensorFlow.


### PR DESCRIPTION
Adds Ferrum under **Libraries → Artificial Intelligence → Machine learning**, between `sipemu/anofox-regression` and `smartcorelib/smartcore`.

I maintain Ferrum. It is a Rust runtime for local text generation, with a CLI and an OpenAI-compatible API supporting Chat Completions and stateless Responses. The entry describes published [v0.8.9](https://github.com/sizzlecar/ferrum-infer-rs/releases/tag/v0.8.9), including Apple Silicon Metal support; it makes no performance claims.

For the contribution guide's alternative popularity-metrics route:

- GitHub traffic reported **2,596 clone events and 419 unique cloners** for **2026-08-25 through 2026-09-07**, observed on **2026-09-09 at 12:53:37 UTC**.
- Clone statistics may include CI and bots. They are not verified users or installations, and I am not claiming that maintainers have already accepted them as equivalent.
- For transparency, GitHub currently shows **14 stars**. crates.io reports **675 downloads for ferrum-engine** and **381 for ferrum-cli**, checked on **2026-09-10**. These crate counts are separate and have not been added together.

The one-line entry follows the repository/crate format, alphabetical placement, and branch-specific CI badge requirement. I checked the README and existing Ferrum/sizzlecar-related PRs for duplicates.

- [x] I have read [CONTRIBUTING.md](https://github.com/rust-unofficial/awesome-rust/blob/main/CONTRIBUTING.md) and am submitting under its alternative-metrics provision for maintainer review.

Prepared with AI assistance; the metrics and released feature scope were checked against their sources.
