### PR TITLE
Add vaulttec-dev/vaulttec-key

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@ If you want to contribute, please read [this](CONTRIBUTING.md).
 * [rmk](https://github.com/haobogu/rmk) - A feature-rich keyboard firmware.
 * [rtic-rs/rtic](https://github.com/rtic-rs/rtic) [[rtic](https://crates.io/crates/rtic)] - Real-Time Interrupt-driven Concurrency framework for building embedded real-time systems.
 * [uefi-rs](https://github.com/rust-osdev/uefi-rs) - Rusty wrapper for the Unified Extensible Firmware Interface. This crate makes it easy to develop Rust software that leverages safe, convenient, and performant abstractions for UEFI functionality.
+* [vaulttec-dev/vaulttec-key](https://github.com/vaulttec-dev/vaulttec-key) - `no_std` USB hardware-key firmware for the ESP32-C6 storing TOTP secrets, passwords and project `.env` files under AES-256-GCM, keyed by Argon2id over a PIN and bound to an eFuse HMAC key, with Secure Boot v2 and a button press for every secret. No HID on that chip, so no WebAuthn. Ships a host CLI that flashes the board.
 
 ### Emulators
 


### PR DESCRIPTION
https://github.com/vaulttec-dev/vaulttec-key

vkey is a USB hardware key on a Waveshare ESP32-C6-Zero that stores TOTP secrets, passwords and whole project `.env` files. Secrets are AES-256-GCM under a key derived from an 8-digit PIN with Argon2id and passed through an HMAC key burned into the chip's eFuse, so a flash dump without that exact chip is useless. Secure Boot v2 is enabled, and every code, password or `.env` requires a physical button press — three different gestures separate use, wipe and encrypted backup.

Firmware is bare-metal Rust on esp-hal: `no_std`, no allocator anywhere, `unsafe_code = "forbid"` and `clippy::pedantic` as errors, no ESP-IDF, no RTOS and no radio crate. The host side is a single static CLI binary that flashes the board and speaks a framed protocol whose definition is one file compiled into both ends. Apache-2.0.

Stated plainly rather than buried: the C6's USB is a hard-wired Serial/JTAG block, so HID and therefore FIDO/WebAuthn are impossible on this hardware and it does nothing against phishing; an ESP32 is not a secure element, and the published fault-injection work on the C3/C6 (Espressif AR2023-007) is not addressed. The repo's threat model documents this, along with a list of marketing claims the project forbids itself. Nothing is for sale.
